### PR TITLE
fix: add duration unit conversion support (ms in seconds, etc.)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-07T13:18:24.338Z for PR creation at branch issue-147-bc6afe7a2d58 for issue https://github.com/link-assistant/calculator/issues/147

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-07T13:18:24.338Z for PR creation at branch issue-147-bc6afe7a2d58 for issue https://github.com/link-assistant/calculator/issues/147

--- a/changelog.d/20260507_000000_fix_ms_to_seconds_conversion.md
+++ b/changelog.d/20260507_000000_fix_ms_to_seconds_conversion.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- Fixed milliseconds (ms) to seconds conversion not being recognized (e.g., `300000 ms in seconds`)

--- a/docs/case-studies/issue-147/analysis.md
+++ b/docs/case-studies/issue-147/analysis.md
@@ -1,0 +1,111 @@
+# Case Study: Issue #147 — Unrecognized input: `300000 ms in seconds`
+
+## Issue Details
+
+- **Repository**: https://github.com/link-assistant/calculator
+- **Issue**: #147
+- **Title**: Unrecognized input: 300000 ms in seconds
+- **State**: Open
+- **Labels**: bug
+- **Author**: konard (Konstantin Diachenko)
+
+## Input that Failed to Parse
+
+```
+300000 ms in seconds
+```
+
+## Error Message
+
+```
+Parse error: Unknown unit 'seconds'. Supported conversions: data sizes (B, KB, MB, GB, KiB, MiB, GiB, ...), mass (g, kg, tons, lb, oz), currencies (USD, EUR, GBP, TON, BTC, ETH, ...) and natural language aliases (dollars, euros, bitcoin, toncoin, ...), timezones (UTC, GMT, EST, MSK, JST, ...).
+```
+
+## Expected Behavior
+
+`ms` (milliseconds) to `seconds` conversion should work.
+
+## Timeline / Sequence of Events
+
+1. User inputs `300000 ms in seconds`
+2. Lexer tokenizes the input: `[Number(300000), Identifier(ms), In, Identifier(seconds)]`
+3. Parser sees `300000 ms` → recognized as `Expression::Number { value: 300000, unit: Unit::Duration(DurationUnit::Milliseconds) }`
+4. Parser sees `in` keyword → calls `parse_unit_for_conversion()`
+5. `parse_unit_for_conversion()` tries:
+   - `DataSizeUnit::parse("seconds")` → None
+   - `MassUnit::parse("seconds")` → None
+   - Case-insensitive data size → None
+   - Case-insensitive mass → None
+   - Timezone check → None
+   - `CurrencyDatabase::parse_currency("seconds")` → None
+6. Returns error: `Unknown unit 'seconds'`
+
+## Root Cause Analysis
+
+### Root Cause 1: `parse_unit_for_conversion` omits Duration units
+
+**File**: `src/grammar/token_parser.rs`, function `parse_unit_for_conversion` (line ~816)
+
+The function handles unit conversions after `as`/`in`/`to` keywords. It tries DataSize, Mass, Timezone, and Currency units — but **completely omits `DurationUnit`**. This means time unit names like "seconds", "ms", "minutes", "hours" are never recognized as valid conversion targets.
+
+**Evidence**: `DurationUnit::parse()` in `src/types/unit.rs` (line ~553) correctly handles all these aliases:
+```rust
+"ms" | "millisecond" | "milliseconds" => Some(Self::Milliseconds),
+"s" | "sec" | "secs" | "second" | "seconds" => Some(Self::Seconds),
+"min" | "mins" | "minute" | "minutes" => Some(Self::Minutes),
+"h" | "hr" | "hrs" | "hour" | "hours" => Some(Self::Hours),
+```
+
+### Root Cause 2: `convert_to_unit_at_date` lacks Duration→Duration case
+
+**File**: `src/types/value/mod.rs`, function `convert_to_unit_at_date` (line ~631)
+
+The function handles DataSize→DataSize, Currency→Currency, Mass→Mass, and Timezone conversions. It has **no handler for Duration→Duration** conversions.
+
+## Solution Plan
+
+### Fix 1: Add `DurationUnit` check in `parse_unit_for_conversion`
+
+In `src/grammar/token_parser.rs`, add before the error return:
+
+```rust
+// Try duration/time unit (e.g., "seconds", "ms", "minutes", "hours")
+if let Some(duration) = crate::types::DurationUnit::parse(&unit_str) {
+    return Ok(Unit::Duration(duration));
+}
+```
+
+### Fix 2: Add Duration→Duration case in `convert_to_unit_at_date`
+
+In `src/types/value/mod.rs`, add a new match arm for `Duration(from) → Duration(to)`:
+
+```rust
+(Unit::Duration(from), Unit::Duration(to)) => {
+    let value_f64 = self.as_decimal().ok_or_else(|| {
+        CalculatorError::InvalidOperation(
+            "duration conversion requires a numeric value".into(),
+        )
+    })?;
+    // Convert: from → seconds → to
+    let secs = from.to_secs(value_f64.to_f64());
+    let result = to.secs_to_unit(secs);
+    Ok(Value::number_with_unit(
+        Decimal::from_f64(result),
+        Unit::Duration(*to),
+    ))
+}
+```
+
+## Test Cases
+
+- `300000 ms in seconds` → `300` (300,000 ms / 1000 = 300 s)
+- `5 minutes in seconds` → `300`
+- `2 hours in minutes` → `120`
+- `1 hour in ms` → `3600000`
+
+## Related Code Locations
+
+- `src/grammar/token_parser.rs:816` — `parse_unit_for_conversion()`
+- `src/types/unit.rs:548` — `DurationUnit::parse()`
+- `src/types/value/mod.rs:631` — `convert_to_unit_at_date()`
+- `src/grammar/number_grammar.rs:93` — duration unit parsing for source (already works)

--- a/src/grammar/token_parser.rs
+++ b/src/grammar/token_parser.rs
@@ -840,6 +840,11 @@ impl<'a> TokenParser<'a> {
                 return Ok(Unit::Mass(mass));
             }
 
+            // Try duration/time unit (e.g., "seconds", "ms", "minutes", "hours")
+            if let Some(duration) = crate::types::DurationUnit::parse(&unit_str) {
+                return Ok(Unit::Duration(duration));
+            }
+
             // Try timezone abbreviation (before currency, since currency catch-all matches any 2-5 letter code)
             if crate::types::DateTime::parse_tz_abbreviation(&unit_str).is_some() {
                 return Ok(Unit::Timezone(unit_str.to_uppercase()));
@@ -858,7 +863,8 @@ impl<'a> TokenParser<'a> {
                  mass (g, kg, tons, lb, oz), \
                  currencies (USD, EUR, GBP, TON, BTC, ETH, ...) and natural language \
                  aliases (dollars, euros, bitcoin, toncoin, ...), \
-                 timezones (UTC, GMT, EST, MSK, JST, ...)."
+                 timezones (UTC, GMT, EST, MSK, JST, ...), \
+                 time durations (ms, seconds, minutes, hours, days, weeks, months, years)."
             )))
         } else {
             Err(CalculatorError::parse(

--- a/src/types/value/mod.rs
+++ b/src/types/value/mod.rs
@@ -675,6 +675,20 @@ impl Value {
                     Unit::Mass(*to),
                 ))
             }
+            // Duration to duration conversion (e.g., "300000 ms in seconds")
+            (Unit::Duration(from), Unit::Duration(to)) => {
+                let value_f64 = self.as_decimal().ok_or_else(|| {
+                    CalculatorError::InvalidOperation(
+                        "duration conversion requires a numeric value".into(),
+                    )
+                })?;
+                let secs = from.to_secs(value_f64.to_f64());
+                let result = to.secs_to_unit(secs);
+                Ok(Value::number_with_unit(
+                    Decimal::from_f64(result),
+                    Unit::Duration(*to),
+                ))
+            }
             // Dimensionless value: just apply the target unit (e.g. "5 as MB")
             (Unit::None, Unit::DataSize(_)) => {
                 let value_f64 = self.as_decimal().ok_or_else(|| {

--- a/tests/issue_147_ms_to_seconds_tests.rs
+++ b/tests/issue_147_ms_to_seconds_tests.rs
@@ -1,0 +1,150 @@
+//! Tests for issue #147: Unrecognized input: `300000 ms in seconds`.
+//!
+//! Root cause 1: `parse_unit_for_conversion` in `token_parser.rs` never tried
+//! `DurationUnit::parse()`, so time unit names like "seconds", "ms", "minutes"
+//! were not recognized as valid conversion targets after "as"/"in"/"to".
+//!
+//! Root cause 2: `convert_to_unit_at_date` in `value/mod.rs` had no
+//! Duration→Duration match arm, so even if the parse succeeded the conversion
+//! would fall through to the catch-all error.
+//!
+//! Fix: Added `DurationUnit::parse()` check in `parse_unit_for_conversion` and
+//! a `(Unit::Duration(from), Unit::Duration(to))` arm in `convert_to_unit_at_date`.
+
+use link_calculator::Calculator;
+
+/// The exact expression from the issue report must succeed and return 300 seconds.
+#[test]
+fn test_300000_ms_in_seconds() {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("300000 ms in seconds");
+    assert!(
+        result.success,
+        "300000 ms in seconds should succeed: {:?}",
+        result.error
+    );
+    assert!(
+        result.result.contains("300"),
+        "300000 ms = 300 seconds, got: {}",
+        result.result
+    );
+}
+
+/// "in" keyword variant using short unit names.
+#[test]
+fn test_ms_to_s_short() {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("1000 ms in s");
+    assert!(
+        result.success,
+        "1000 ms in s should succeed: {:?}",
+        result.error
+    );
+    assert!(
+        result.result.contains('1'),
+        "1000 ms = 1 second, got: {}",
+        result.result
+    );
+}
+
+/// "as" keyword variant.
+#[test]
+fn test_ms_as_seconds() {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("5000 ms as seconds");
+    assert!(
+        result.success,
+        "5000 ms as seconds should succeed: {:?}",
+        result.error
+    );
+    assert!(
+        result.result.contains('5'),
+        "5000 ms = 5 seconds, got: {}",
+        result.result
+    );
+}
+
+/// "to" keyword variant.
+#[test]
+fn test_ms_to_seconds_keyword() {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("2000 ms to seconds");
+    assert!(
+        result.success,
+        "2000 ms to seconds should succeed: {:?}",
+        result.error
+    );
+    assert!(
+        result.result.contains('2'),
+        "2000 ms = 2 seconds, got: {}",
+        result.result
+    );
+}
+
+/// Minutes to seconds conversion.
+#[test]
+fn test_minutes_to_seconds() {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("5 minutes in seconds");
+    assert!(
+        result.success,
+        "5 minutes in seconds should succeed: {:?}",
+        result.error
+    );
+    assert!(
+        result.result.contains("300"),
+        "5 minutes = 300 seconds, got: {}",
+        result.result
+    );
+}
+
+/// Hours to minutes conversion.
+#[test]
+fn test_hours_to_minutes() {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("2 hours in minutes");
+    assert!(
+        result.success,
+        "2 hours in minutes should succeed: {:?}",
+        result.error
+    );
+    assert!(
+        result.result.contains("120"),
+        "2 hours = 120 minutes, got: {}",
+        result.result
+    );
+}
+
+/// Seconds to milliseconds (reverse direction).
+#[test]
+fn test_seconds_to_ms() {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("1 second in ms");
+    assert!(
+        result.success,
+        "1 second in ms should succeed: {:?}",
+        result.error
+    );
+    assert!(
+        result.result.contains("1000"),
+        "1 second = 1000 ms, got: {}",
+        result.result
+    );
+}
+
+/// Hours to seconds conversion.
+#[test]
+fn test_hours_to_seconds() {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("1 hour in seconds");
+    assert!(
+        result.success,
+        "1 hour in seconds should succeed: {:?}",
+        result.error
+    );
+    assert!(
+        result.result.contains("3600"),
+        "1 hour = 3600 seconds, got: {}",
+        result.result
+    );
+}


### PR DESCRIPTION
## Problem

`300000 ms in seconds` failed with:
```
Parse error: Unknown unit 'seconds'. Supported conversions: data sizes (B, KB, MB, GB, KiB, MiB, GiB, ...), mass (g, kg, tons, lb, oz), currencies (USD, EUR, GBP, TON, BTC, ETH, ...) and natural language aliases (dollars, euros, bitcoin, toncoin, ...), timezones (UTC, GMT, EST, MSK, JST, ...).
```

Closes #147.

## Root Causes

### Root cause 1 — `parse_unit_for_conversion` omitted `DurationUnit`

**File**: `src/grammar/token_parser.rs`, `parse_unit_for_conversion()`

The function handles conversion targets after `as`/`in`/`to` keywords and tried DataSize, Mass, Timezone, and Currency — but never `DurationUnit::parse()`. So time unit names like `"seconds"`, `"ms"`, `"minutes"`, `"hours"` were rejected with "Unknown unit".

### Root cause 2 — `convert_to_unit_at_date` had no `Duration→Duration` arm

**File**: `src/types/value/mod.rs`, `convert_to_unit_at_date()`

Even if parsing succeeded, the conversion would fall through to the catch-all error because there was no match arm for `(Unit::Duration(from), Unit::Duration(to))`.

## Fix

1. Added `DurationUnit::parse()` check in `parse_unit_for_conversion` (`token_parser.rs`).
2. Added `(Unit::Duration(from), Unit::Duration(to))` arm in `convert_to_unit_at_date` (`value/mod.rs`), converting via seconds as the intermediate unit.
3. Updated the error message to mention time durations in the supported list.

## How to Reproduce

```
300000 ms in seconds
```
Expected: `300`
Before fix: parse error on `'seconds'`
After fix: returns `300`

## Tests

8 new regression tests in `tests/issue_147_ms_to_seconds_tests.rs`:

- `300000 ms in seconds` → 300
- `1000 ms in s` → 1
- `5000 ms as seconds` → 5
- `2000 ms to seconds` → 2
- `5 minutes in seconds` → 300
- `2 hours in minutes` → 120
- `1 second in ms` → 1000
- `1 hour in seconds` → 3600

All existing tests continue to pass (no regressions).

## Case Study

Deep analysis in `docs/case-studies/issue-147/analysis.md`.