### PR TITLE
fix: support SI suffixes before units

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-20T14:24:12.490Z for PR creation at branch issue-162-d2d7c23e91a5 for issue https://github.com/link-assistant/calculator/issues/162

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-20T14:24:12.490Z for PR creation at branch issue-162-d2d7c23e91a5 for issue https://github.com/link-assistant/calculator/issues/162

--- a/changelog.d/20260520_143038_support_si_number_suffixes.md
+++ b/changelog.d/20260520_143038_support_si_number_suffixes.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- Treat adjacent SI number suffixes such as `19k` and `19к` as numeric multipliers before parsing following units.

--- a/src/grammar/number_grammar.rs
+++ b/src/grammar/number_grammar.rs
@@ -31,6 +31,46 @@ impl NumberGrammar {
         Ok(if is_negative { -decimal } else { decimal })
     }
 
+    /// Returns the decimal multiplier for an SI-style numeric suffix.
+    ///
+    /// This is used for compact number notation such as `19k RUB` and
+    /// `19к рублей`, where the suffix is attached to the number and the unit
+    /// follows as the next token. SI suffixes are case-sensitive where case
+    /// distinguishes multipliers, so `m` is milli and `M` is mega. `K`/`К`
+    /// are accepted as common user spellings of kilo.
+    #[must_use]
+    pub(crate) fn si_suffix_multiplier(s: &str) -> Option<Decimal> {
+        let multiplier = match s {
+            // Submultiples
+            "r" => "0.000000000000000000000000001",
+            "y" => "0.000000000000000000000001",
+            "z" => "0.000000000000000000001",
+            "a" => "0.000000000000000001",
+            "f" => "0.000000000000001",
+            "p" => "0.000000000001",
+            "n" => "0.000000001",
+            "µ" | "μ" | "u" => "0.000001",
+            "m" => "0.001",
+            "c" => "0.01",
+            "d" => "0.1",
+            // Multiples
+            "da" => "10",
+            "h" => "100",
+            "k" | "K" | "к" | "К" => "1000",
+            "M" | "М" => "1000000",
+            "G" => "1000000000",
+            "T" => "1000000000000",
+            "P" => "1000000000000000",
+            "E" => "1000000000000000000",
+            "Z" => "1000000000000000000000",
+            "Y" => "1000000000000000000000000",
+            "R" => "1000000000000000000000000000",
+            _ => return None,
+        };
+
+        multiplier.parse().ok()
+    }
+
     /// Parses a number with an optional unit.
     pub fn parse_number_with_unit(
         &self,

--- a/src/grammar/token_parser.rs
+++ b/src/grammar/token_parser.rs
@@ -191,6 +191,7 @@ impl<'a> TokenParser<'a> {
         // Number with optional unit
         if let Some(TokenKind::Number(n)) = self.current_kind() {
             let num_str = n.clone();
+            let number_end = self.current().map_or(0, |token| token.end);
             let save_pos = self.pos;
             self.advance();
 
@@ -241,6 +242,11 @@ impl<'a> TokenParser<'a> {
                 }
             }
 
+            let mut value = self.number_grammar.parse_number(&num_str)?;
+            if let Some(multiplier) = self.consume_adjacent_si_suffix(number_end) {
+                value = value * multiplier;
+            }
+
             // Check for unit (identifier following number that is not a function)
             let (unit, alternative_units) =
                 if let Some(TokenKind::Identifier(id)) = self.current_kind() {
@@ -259,7 +265,6 @@ impl<'a> TokenParser<'a> {
                     (Unit::None, Vec::new())
                 };
 
-            let value = self.number_grammar.parse_number(&num_str)?;
             if alternative_units.is_empty() {
                 return Ok(Expression::number_with_unit(value, unit));
             }
@@ -355,6 +360,46 @@ impl<'a> TokenParser<'a> {
             "Unexpected token: {:?}",
             self.current()
         )))
+    }
+
+    fn consume_adjacent_si_suffix(&mut self, number_end: usize) -> Option<Decimal> {
+        let suffix = self.current().and_then(|token| {
+            if token.start != number_end {
+                return None;
+            }
+
+            let TokenKind::Identifier(id) = &token.kind else {
+                return None;
+            };
+
+            Some(id.clone())
+        })?;
+        let multiplier = NumberGrammar::si_suffix_multiplier(&suffix)?;
+
+        // Preserve established adjacent unit abbreviations like `2h in minutes`.
+        // They become SI suffixes only in suffix-before-unit forms like `5h USD`.
+        if self.identifier_is_known_unit(&suffix) && !self.peek_identifier_is_known_unit() {
+            return None;
+        }
+
+        self.advance();
+        Some(multiplier)
+    }
+
+    fn identifier_is_known_unit(&self, id: &str) -> bool {
+        matches!(
+            self.number_grammar.parse_unit_with_alternatives(id),
+            Ok((unit, _)) if !matches!(unit, Unit::Custom(_) | Unit::None)
+        )
+    }
+
+    fn peek_identifier_is_known_unit(&self) -> bool {
+        match self.peek_kind() {
+            Some(TokenKind::Identifier(id)) if !is_math_function(id) => {
+                self.identifier_is_known_unit(id)
+            }
+            _ => false,
+        }
     }
 
     fn parse_function_call(&mut self, name: &str) -> Result<Expression, CalculatorError> {

--- a/tests/issue_162_si_suffix_tests.rs
+++ b/tests/issue_162_si_suffix_tests.rs
@@ -1,0 +1,108 @@
+//! Regression tests for issue #162: adjacent SI suffixes before units.
+//!
+//! The original failure parsed `19к рублей в долларах` as `19 к` and then
+//! rejected the trailing `рублей`. The suffix should scale the number first,
+//! so the expression is equivalent to `19000 рублей в долларах`.
+
+use link_calculator::grammar::ExpressionParser;
+use link_calculator::types::{Decimal, Expression, Unit};
+use link_calculator::Calculator;
+
+fn assert_currency_conversion(input: &str, expected_value: &str, source: &str, target: &str) {
+    let parser = ExpressionParser::new();
+    let expr = parser
+        .parse(input)
+        .unwrap_or_else(|err| panic!("{input:?} should parse, got {err}"));
+
+    let Expression::UnitConversion { value, target_unit } = expr else {
+        panic!("{input:?} should parse as a unit conversion");
+    };
+    assert_eq!(target_unit, Unit::currency(target));
+
+    let Expression::Number { value, unit, .. } = *value else {
+        panic!("{input:?} source should be a number with a unit");
+    };
+    assert_eq!(value, expected_value.parse::<Decimal>().unwrap());
+    assert_eq!(unit, Unit::currency(source));
+}
+
+#[test]
+fn issue_162_cyrillic_k_scales_before_russian_currency_unit() {
+    assert_currency_conversion("19к рублей в долларах", "19000", "RUB", "USD");
+}
+
+#[test]
+fn issue_162_exact_input_evaluates_as_19000_rub_to_usd() {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("19к рублей в долларах");
+
+    assert!(
+        result.success,
+        "19к рублей в долларах should succeed, got error: {:?}",
+        result.error
+    );
+    assert_eq!(result.lino_interpretation, "((19000 RUB) as USD)");
+    assert!(
+        result.result.contains("USD"),
+        "Result should be in USD, got {}",
+        result.result
+    );
+}
+
+#[test]
+fn issue_162_latin_k_scales_before_currency_units_across_languages() {
+    for input in [
+        "19k rubles in dollars",
+        "19k рублей в долларах",
+        "19k roubles en dollars",
+        "19k 卢布 换成 美元",
+        "19k रूबल में डॉलर",
+        "19k روبل إلى دولار",
+    ] {
+        assert_currency_conversion(input, "19000", "RUB", "USD");
+    }
+}
+
+#[test]
+fn issue_162_decimal_and_larger_si_suffixes_scale_values() {
+    for (input, expected_value) in [
+        ("1.5k USD in EUR", "1500"),
+        ("2M USD in EUR", "2000000"),
+        ("3G USD in EUR", "3000000000"),
+    ] {
+        assert_currency_conversion(input, expected_value, "USD", "EUR");
+    }
+}
+
+#[test]
+fn issue_162_si_suffixes_follow_case_sensitive_meanings() {
+    for (input, expected_value) in [
+        ("500m USD in EUR", "0.5"),
+        ("7u USD in EUR", "0.000007"),
+        ("4da USD in EUR", "40"),
+        ("5h USD in EUR", "500"),
+    ] {
+        assert_currency_conversion(input, expected_value, "USD", "EUR");
+    }
+}
+
+#[test]
+fn issue_162_adjacent_duration_abbreviations_still_parse_as_units() {
+    let mut calc = Calculator::new();
+
+    let hours = calc.calculate_internal("2h in minutes");
+    assert!(
+        hours.success,
+        "2h in minutes should still parse as hours, got error: {:?}",
+        hours.error
+    );
+    assert_eq!(hours.result, "120 minutes");
+
+    let days = calc.calculate_internal("3d in hours");
+    assert!(
+        days.success,
+        "3d in hours should still parse as days, got error: {:?}",
+        days.error
+    );
+    assert_eq!(days.result, "72 hours");
+}


### PR DESCRIPTION
## Summary

- Added adjacent SI suffix handling before unit parsing, so `19k RUB` and `19к рублей` scale to `19000 RUB`.
- Kept existing adjacent unit abbreviations intact when they stand alone, such as `2h in minutes` parsing as hours.
- Added issue #162 regression coverage for the exact Russian input, multilingual currency forms, decimal/larger SI suffixes, fractional suffixes, and duration shorthand compatibility.

## Reproduction

Before this change:

```text
19к рублей в долларах
Parse error: Unexpected trailing input 'рублей' at position 4
```

After this change:

```text
19к рублей в долларах
Links notation: ((19000 RUB) as USD)
```

## Tests

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo test --test issue_162_si_suffix_tests`
- `cargo test --all-features`
- `cargo test --doc`
- `node scripts/check-file-size.mjs`
- `GITHUB_BASE_REF=main node scripts/check-changelog-fragment.mjs`

Fixes #162
