### PR TITLE
fix(parser): reject bare decimal points without tokenization loop

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-04T20:00:11.545Z for PR creation at branch issue-168-9b64bc6696af for issue https://github.com/link-assistant/calculator/issues/168

--- a/changelog.d/20260604_200441_issue_168_bare_dot.md
+++ b/changelog.d/20260604_200441_issue_168_bare_dot.md
@@ -1,0 +1,8 @@
+---
+bump: patch
+---
+
+### Fixed
+- Reject bare or dangling decimal points such as `2. 3`, `2+2. 3+3`, `2.`,
+  and `. 3` as recoverable parse errors instead of looping during tokenization
+  until the process aborts from memory allocation failure (issue #168).

--- a/src/grammar/lexer.rs
+++ b/src/grammar/lexer.rs
@@ -300,10 +300,10 @@ impl Lexer {
                     self.pos = end;
                     token
                 } else {
-                    self.scan_number()
+                    self.scan_number()?
                 }
             }
-            _ if ch == '.' => self.scan_number(),
+            _ if ch == '.' => self.scan_number()?,
             _ if ch.is_alphabetic() => self.scan_identifier(),
             // Currency symbols used as prefix notation (e.g., $10, €5, £3)
             // These are recognized as single-character identifiers and mapped to ISO codes
@@ -328,10 +328,16 @@ impl Lexer {
         Ok(token)
     }
 
-    fn scan_number(&mut self) -> Token {
+    fn scan_number(&mut self) -> Result<Token, CalculatorError> {
         let start = self.pos;
         let mut text = String::new();
         let mut has_dot = false;
+
+        if self.current() == '.' && !self.peek().is_some_and(|c| c.is_ascii_digit()) {
+            return Err(CalculatorError::parse(format!(
+                "Unexpected character '.' at position {start}"
+            )));
+        }
 
         while !self.is_at_end() {
             let ch = self.current();
@@ -352,7 +358,12 @@ impl Lexer {
             }
         }
 
-        Token::new(TokenKind::Number(text.clone()), start, self.pos, text)
+        Ok(Token::new(
+            TokenKind::Number(text.clone()),
+            start,
+            self.pos,
+            text,
+        ))
     }
 
     /// Attempts to scan a full numeric date literal starting at the current

--- a/tests/issue_168_bare_dot_tests.rs
+++ b/tests/issue_168_bare_dot_tests.rs
@@ -1,0 +1,50 @@
+//! Regression coverage for issue #168.
+//!
+//! A standalone `.` used to lex as a zero-length number token. Because the
+//! lexer did not advance, full tokenization looped until the process aborted
+//! with an allocation failure.
+
+use link_calculator::grammar::Lexer;
+use link_calculator::Calculator;
+
+#[test]
+fn issue_168_lexer_rejects_standalone_dot_without_loop() {
+    let mut lexer = Lexer::new(".");
+
+    let error = lexer
+        .next_token()
+        .expect_err("standalone dot must be rejected, not emitted as an empty token");
+
+    assert!(
+        error.to_string().contains("Unexpected character '.'"),
+        "error should mention the bare dot, got: {error}"
+    );
+}
+
+#[test]
+fn issue_168_calculate_with_value_rejects_bare_or_dangling_dot_inputs() {
+    for input in ["2. 3", "2+2. 3+3", "2.", ". 3"] {
+        let mut calculator = Calculator::new();
+
+        let error = calculator
+            .calculate_with_value(input)
+            .expect_err("bare or dangling dot input must return a recoverable error");
+
+        assert!(
+            error.to_string().contains("Unexpected character '.'"),
+            "{input:?} should mention the invalid dot, got: {error}"
+        );
+    }
+}
+
+#[test]
+fn issue_168_valid_decimals_still_evaluate() {
+    let mut calculator = Calculator::new();
+
+    let (_expression, value, _steps, lino) = calculator
+        .calculate_with_value("3.14 + 2.5")
+        .expect("well-formed decimal expression should still evaluate");
+
+    assert_eq!(value.to_display_string(), "5.64");
+    assert_eq!(lino, "(3.14 + 2.5)");
+}


### PR DESCRIPTION
## Summary

- Fixes #168 by rejecting bare or dangling `.` tokens as parse errors instead of emitting a zero-length number token.
- Keeps well-formed decimal expressions such as `3.14 + 2.5` working.
- Adds regression coverage for the exact reported inputs and a changelog fragment.

## Root cause

The crash was in the lexer, before evaluation. `scan_number()` could return `TokenKind::Number("")` for a standalone `.`, without advancing `self.pos`. Full tokenization then looped on the same byte and kept appending tokens until allocation failed.

## Reproduction

Before this change:

```text
2. 3
memory allocation failed / process abort
```

After this change:

```text
2. 3
Parse error: Unexpected character '.' at position 1
```

The same recoverable parse path covers `2+2. 3+3`, `2.`, and `. 3`.

## Tests

- `cargo test --test issue_168_bare_dot_tests -- --nocapture`
- `cargo test test_tokenize_decimal -- --nocapture`
- `cargo test --test issue_166_numeric_date_parsing_tests -- --nocapture`
- `cargo fmt --all -- --check`
- `RUSTFLAGS=-Dwarnings cargo clippy --all-targets --all-features`
- `RUSTFLAGS=-Dwarnings cargo test --all-features --verbose`
- `RUSTFLAGS=-Dwarnings cargo test --doc --verbose`
- `RUSTFLAGS=-Dwarnings cargo build --release --verbose`
- `cargo package --list --allow-dirty`
- `node scripts/check-file-size.mjs`
- `GITHUB_BASE_REF=main node scripts/check-changelog-fragment.mjs`
- `GITHUB_EVENT_NAME=pull_request GITHUB_HEAD_REF=issue-168-9b64bc6696af GITHUB_BASE_REF=main node scripts/check-version-modification.mjs`
- `wasm-pack build --target web --out-dir web/public/pkg`
- `npm ci`
- `npx tsc --noEmit`
- `npm run build`

Note: `npm ci` completed with existing audit warnings; no dependency files were changed.

Fixes #168
