### PR TITLE
fix(parser): support Russian percent-of connector

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-04T20:00:11.545Z for PR creation at branch issue-168-9b64bc6696af for issue https://github.com/link-assistant/calculator/issues/168
+# Updated: 2026-06-08T16:45:47.372Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-06-04T20:00:11.545Z for PR creation at branch issue-168-9b64bc6696af for issue https://github.com/link-assistant/calculator/issues/168
-# Updated: 2026-06-08T16:45:47.372Z

--- a/changelog.d/20260608_170000_issue_170_russian_percent_of.md
+++ b/changelog.d/20260608_170000_issue_170_russian_percent_of.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- Recognize Russian `от` in percent-of expressions such as `38% от 100к`.

--- a/src/grammar/lexer.rs
+++ b/src/grammar/lexer.rs
@@ -469,6 +469,8 @@ impl Lexer {
             "to" => TokenKind::To,
             "until" => TokenKind::Until,
             "of" => TokenKind::Of,
+            // Russian: "от" means "of/from" in percent-of expressions (e.g. "38% от 100к").
+            "от" => TokenKind::Of,
             // Russian: "в" means "in/into" (e.g. "1000 рублей в долларах")
             "в" => TokenKind::In,
             // Russian: "по" means "by/according to" for timezone context (e.g. "11 по мск").

--- a/tests/issue_170_russian_percent_of_tests.rs
+++ b/tests/issue_170_russian_percent_of_tests.rs
@@ -1,0 +1,32 @@
+//! Regression tests for issue #170: Russian percent-of connector.
+
+use link_calculator::grammar::{Lexer, TokenKind};
+use link_calculator::Calculator;
+
+#[test]
+fn issue_170_exact_russian_percent_of_input_evaluates() {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("38% от 100к");
+
+    assert!(
+        result.success,
+        "38% от 100к should succeed, got error: {:?}",
+        result.error
+    );
+    assert_eq!(result.result, "38000");
+    assert_eq!(result.lino_interpretation, "((38 / 100) * 100000)");
+}
+
+#[test]
+fn issue_170_russian_ot_tokenizes_as_percent_of_connector() {
+    let mut lexer = Lexer::new("38% от 100к");
+    let tokens = lexer
+        .tokenize()
+        .unwrap_or_else(|err| panic!("lexing should succeed: {err}"));
+
+    assert!(
+        matches!(tokens.get(2).map(|token| &token.kind), Some(TokenKind::Of)),
+        "expected `от` to tokenize as Of, got {:?}",
+        tokens.get(2)
+    );
+}


### PR DESCRIPTION
Fixes #170

## Summary
- Recognize Russian `от` as the percent-of connector used by expressions like `38% от 100к`.
- Reuse the existing `TokenKind::Of` parser path so English percent-of behavior and `%` modulo parsing remain unchanged.
- Add a patch changelog fragment.

## Reproduction
Before this change, `38% от 100к` failed with `Parse error: Unexpected identifier: от`.

After this change, `38% от 100к` evaluates to `38000` with interpretation `((38 / 100) * 100000)`.

## Tests
- `cargo test --test issue_170_russian_percent_of_tests -- --nocapture`
- `cargo test --test issue_145_percent_of_tests -- --nocapture`
- `cargo test --test issue_158_modulo_and_strict_parse_tests -- --nocapture`
- `cargo test --test issue_162_si_suffix_tests -- --nocapture`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features`
- `node scripts/check-file-size.mjs`
- `node scripts/check-changelog-fragment.mjs`
- `cargo test`
