### PR TITLE
Fix localization coverage for calculator output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -318,6 +318,10 @@ jobs:
         working-directory: web
         run: npx tsc --noEmit
 
+      - name: Run web tests
+        working-directory: web
+        run: npm test
+
       - name: Build
         working-directory: web
         run: npm run build

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-04T20:00:11.545Z for PR creation at branch issue-168-9b64bc6696af for issue https://github.com/link-assistant/calculator/issues/168
+# Updated: 2026-06-08T17:17:25.941Z

--- a/changelog.d/20260608_173000_issue_171_i18n_coverage.md
+++ b/changelog.d/20260608_173000_issue_171_i18n_coverage.md
@@ -1,0 +1,5 @@
+### Fixed
+- Localized calculation steps and generated issue-report reproduction steps instead of showing raw English text in non-English languages.
+
+### Added
+- Added web test coverage and CI execution for translation key parity across supported languages.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import { useTheme, useUrlExpression, useDelayedLoading, useExpressionCache } from './hooks';
 import { SUPPORTED_LANGUAGES, loadPreferences, savePreferences } from './i18n';
+import { localizeCalculationSteps } from './utils/localizeCalculation';
 import { generateIssueUrl, type PageState } from './utils/reportIssue';
 import { formatLocalDateTime, formatUtcDateTime } from './utils/datetimeDisplay';
 import { AutoResizeTextarea, ColorCodedLino, RepeatingDecimalNotations, UniversalKeyboard, type AutoResizeTextareaRef } from './components';
@@ -406,9 +407,15 @@ function App() {
   };
 
   const handleReportIssue = () => {
+    const localizedResult = result
+      ? {
+          ...result,
+          steps: localizeCalculationSteps(t, result),
+        }
+      : null;
     const pageState: PageState = {
       expression: input,
-      result,
+      result: localizedResult,
       wasmReady,
       version,
       theme: resolvedTheme,
@@ -436,6 +443,7 @@ function App() {
 
   // Determine if RTL language
   const isRtl = i18n.language === 'ar';
+  const localizedSteps = result ? localizeCalculationSteps(t, result) : [];
 
   return (
     <div className={`app-wrapper ${isRtl ? 'rtl' : ''}`} dir={isRtl ? 'rtl' : 'ltr'}>
@@ -722,11 +730,11 @@ function App() {
                     )}
 
                     {/* Section 5: Steps / Reasoning (optional) */}
-                    {result.steps.length > 0 && !result.is_symbolic && (
+                    {localizedSteps.length > 0 && !result.is_symbolic && (
                       <div className="steps-section">
                         <h3>{t('result.steps')}</h3>
                         <ul className="steps-list">
-                          {result.steps.map((step, i) => (
+                          {localizedSteps.map((step, i) => (
                             <li key={i}>{step}</li>
                           ))}
                         </ul>

--- a/web/src/i18n/index.test.ts
+++ b/web/src/i18n/index.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { encodePreferences, decodePreferences, loadPreferences, savePreferences, parseLinoToI18n, type Preferences } from './index';
+import arLino from './locales/ar.lino?raw';
+import deLino from './locales/de.lino?raw';
+import enLino from './locales/en.lino?raw';
+import frLino from './locales/fr.lino?raw';
+import hiLino from './locales/hi.lino?raw';
+import ruLino from './locales/ru.lino?raw';
+import zhLino from './locales/zh.lino?raw';
 
 // Mock localStorage
 const localStorageMock = {
@@ -13,6 +20,62 @@ Object.defineProperty(window, 'localStorage', {
   value: localStorageMock,
   writable: true,
 });
+
+const LOCALES = {
+  ar: arLino,
+  de: deLino,
+  en: enLino,
+  fr: frLino,
+  hi: hiLino,
+  ru: ruLino,
+  zh: zhLino,
+} as const;
+
+const REQUIRED_USER_OUTPUT_KEYS = [
+  'errors.unknownError',
+  'result.notations',
+  'result.plot',
+  'issueReport.alternativeInterpretations',
+  'issueReport.reproductionSteps',
+  'issueReport.reproductionOpen',
+  'issueReport.reproductionEnter',
+  'issueReport.reproductionRunCalculation',
+  'issueReport.reproductionUseCalculator',
+  'issueReport.reproductionClickReportIssue',
+  'steps.input',
+  'steps.utcEquivalent',
+  'steps.timeUntil',
+  'steps.timeSince',
+  'steps.currentTime',
+  'steps.timeUntilTarget',
+  'steps.timeSinceTarget',
+  'steps.convert',
+  'steps.indefiniteIntegral',
+  'steps.computedSymbolicResult',
+  'steps.solveLinearEquation',
+  'steps.solution',
+  'steps.checkEquality',
+  'steps.compare',
+] as const;
+
+function flattenTranslations(
+  translations: ReturnType<typeof parseLinoToI18n>,
+  prefix = ''
+): Map<string, string> {
+  const flattened = new Map<string, string>();
+
+  Object.entries(translations).forEach(([section, values]) => {
+    Object.entries(values).forEach(([key, value]) => {
+      flattened.set(prefix ? `${prefix}.${section}.${key}` : `${section}.${key}`, value);
+    });
+  });
+
+  return flattened;
+}
+
+function interpolationKeys(value: string): string[] {
+  return Array.from(value.matchAll(/\{\{([^}]+)\}\}/g), match => match[1]).sort();
+}
 
 describe('i18n preferences', () => {
   beforeEach(() => {
@@ -222,6 +285,56 @@ footer:
       const result = parseLinoToI18n('');
 
       expect(result).toEqual({});
+    });
+  });
+
+  describe('translation coverage', () => {
+    it('should keep every supported locale in key parity with English', () => {
+      const parsedLocales = Object.fromEntries(
+        Object.entries(LOCALES).map(([locale, content]) => [
+          locale,
+          flattenTranslations(parseLinoToI18n(content)),
+        ])
+      );
+      const englishKeys = Array.from(parsedLocales.en.keys()).sort();
+
+      Object.entries(parsedLocales).forEach(([locale, translations]) => {
+        const localeKeys = Array.from(translations.keys()).sort();
+        const missingKeys = englishKeys.filter(key => !translations.has(key));
+        const extraKeys = localeKeys.filter(key => !parsedLocales.en.has(key));
+
+        expect(missingKeys, `${locale} is missing translation keys`).toEqual([]);
+        expect(extraKeys, `${locale} has translation keys not present in English`).toEqual([]);
+      });
+    });
+
+    it('should include all user-facing issue-report and calculation-step keys', () => {
+      Object.entries(LOCALES).forEach(([locale, content]) => {
+        const translations = flattenTranslations(parseLinoToI18n(content));
+        const missingKeys = REQUIRED_USER_OUTPUT_KEYS.filter(key => !translations.has(key));
+
+        expect(missingKeys, `${locale} is missing required user-output keys`).toEqual([]);
+      });
+    });
+
+    it('should keep interpolation placeholders consistent with English', () => {
+      const parsedLocales = Object.fromEntries(
+        Object.entries(LOCALES).map(([locale, content]) => [
+          locale,
+          flattenTranslations(parseLinoToI18n(content)),
+        ])
+      );
+
+      parsedLocales.en.forEach((englishValue, key) => {
+        const englishInterpolationKeys = interpolationKeys(englishValue);
+
+        Object.entries(parsedLocales).forEach(([locale, translations]) => {
+          expect(
+            interpolationKeys(translations.get(key) || ''),
+            `${locale}.${key} interpolation placeholders differ from English`
+          ).toEqual(englishInterpolationKeys);
+        });
+      });
     });
   });
 });

--- a/web/src/i18n/locales/ar.lino
+++ b/web/src/i18n/locales/ar.lino
@@ -15,6 +15,8 @@ result:
   timezoneConversions 'تحويلات المنطقة الزمنية'
   localTime 'الوقت المحلي'
   utcTime 'وقت UTC'
+  notations 'تدوينات عشرية'
+  plot 'رسم الدالة'
 examples:
   title 'جرب هذه الأمثلة:'
 errors:
@@ -36,6 +38,7 @@ errors:
   unknownFunction 'دالة غير معروفة: {{name}}'
   invalidFunctionArgs 'وسائط غير صالحة للدالة "{{function}}": {{reason}}'
   domainError 'خطأ في النطاق: {{message}}'
+  unknownError 'خطأ غير معروف'
 footer:
   poweredBy 'مدعوم بـ Rust + WebAssembly'
   viewOnGitHub 'عرض على GitHub'
@@ -57,8 +60,15 @@ share:
   copied 'تم النسخ!'
 steps:
   inputExpression 'تعبير الإدخال: {{expression}}'
+  input 'الإدخال: {{expression}}'
   literalValue 'القيمة الحرفية: {{value}}'
   dateTimeValue 'قيمة التاريخ/الوقت: {{value}}'
+  utcEquivalent 'المكافئ بتوقيت UTC: {{value}}'
+  timeUntil 'الوقت المتبقي: {{duration}}'
+  timeSince 'الوقت المنقضي: {{duration}}'
+  currentTime 'الوقت الحالي: {{time}}'
+  timeUntilTarget 'الوقت المتبقي حتى {{target}}: {{duration}}'
+  timeSinceTarget 'الوقت المنقضي منذ {{target}}: {{duration}}'
   compute 'حساب: {{left}} {{op}} {{right}}'
   equals '= {{value}}'
   negate 'نفي: -{{value}} = {{result}}'
@@ -73,6 +83,13 @@ steps:
   result 'النتيجة: {{value}}'
   finalResult 'النتيجة النهائية: {{value}}'
   exchangeRate 'سعر الصرف: 1 {{from}} = {{rate}} {{to}} (المصدر: {{source}}، التاريخ: {{date}})'
+  convert 'تحويل: {{value}} إلى {{unit}}'
+  indefiniteIntegral 'تكامل غير محدد: ∫ {{integrand}} d{{variable}}'
+  computedSymbolicResult 'تم حساب نتيجة رمزية'
+  solveLinearEquation 'حل المعادلة الخطية:'
+  solution 'الحل: {{value}}'
+  checkEquality 'التحقق من المساواة:'
+  compare 'مقارنة: {{left}} = {{right}}'
 issueReport:
   environment البيئة
   version الإصدار
@@ -86,7 +103,14 @@ issueReport:
   resultSection النتيجة
   resultLabel النتيجة
   linksNotation 'تدوين الروابط'
+  alternativeInterpretations 'تفسيرات بديلة'
   stepsLabel الخطوات
+  reproductionSteps 'خطوات إعادة الإنتاج'
+  reproductionOpen 'افتح {{url}}'
+  reproductionEnter 'أدخل {{expression}}'
+  reproductionRunCalculation 'شغّل الحساب'
+  reproductionUseCalculator 'استخدم الحاسبة حتى تحدث المشكلة'
+  reproductionClickReportIssue 'انقر على الإبلاغ عن مشكلة'
   errorLabel الخطأ
   description الوصف
   descriptionPlaceholder 'يرجى وصف المشكلة التي واجهتها'

--- a/web/src/i18n/locales/de.lino
+++ b/web/src/i18n/locales/de.lino
@@ -15,6 +15,8 @@ result:
   timezoneConversions 'Zeitzonen-Umrechnungen'
   localTime 'Lokale Zeit'
   utcTime 'UTC-Zeit'
+  notations 'Dezimalschreibweisen'
+  plot 'Funktionsgraph'
 examples:
   title 'Probieren Sie diese Beispiele:'
 errors:
@@ -36,6 +38,7 @@ errors:
   unknownFunction 'Unbekannte Funktion: {{name}}'
   invalidFunctionArgs 'Ungültige Argumente für Funktion "{{function}}": {{reason}}'
   domainError 'Definitionsbereichsfehler: {{message}}'
+  unknownError 'Unbekannter Fehler'
 footer:
   poweredBy 'Powered by Rust + WebAssembly'
   viewOnGitHub 'Auf GitHub ansehen'
@@ -57,8 +60,15 @@ share:
   copied Kopiert!
 steps:
   inputExpression 'Eingabeausdruck: {{expression}}'
+  input 'Eingabe: {{expression}}'
   literalValue 'Literalwert: {{value}}'
   dateTimeValue 'Datums-/Zeitwert: {{value}}'
+  utcEquivalent 'UTC-Entsprechung: {{value}}'
+  timeUntil 'Zeit bis dahin: {{duration}}'
+  timeSince 'Zeit seitdem: vor {{duration}}'
+  currentTime 'Aktuelle Zeit: {{time}}'
+  timeUntilTarget 'Zeit bis {{target}}: {{duration}}'
+  timeSinceTarget 'Zeit seit {{target}}: vor {{duration}}'
   compute 'Berechne: {{left}} {{op}} {{right}}'
   equals '= {{value}}'
   negate 'Negation: -{{value}} = {{result}}'
@@ -73,6 +83,13 @@ steps:
   result 'Ergebnis: {{value}}'
   finalResult 'Endergebnis: {{value}}'
   exchangeRate 'Wechselkurs: 1 {{from}} = {{rate}} {{to}} (Quelle: {{source}}, Datum: {{date}})'
+  convert 'Umrechnen: {{value}} in {{unit}}'
+  indefiniteIntegral 'Unbestimmtes Integral: ∫ {{integrand}} d{{variable}}'
+  computedSymbolicResult 'Symbolisches Ergebnis berechnet'
+  solveLinearEquation 'Lineare Gleichung lösen:'
+  solution 'Lösung: {{value}}'
+  checkEquality 'Gleichheit prüfen:'
+  compare 'Vergleichen: {{left}} = {{right}}'
 issueReport:
   environment Umgebung
   version Version
@@ -86,7 +103,14 @@ issueReport:
   resultSection Ergebnis
   resultLabel Ergebnis
   linksNotation Links-Notation
+  alternativeInterpretations 'Alternative Interpretationen'
   stepsLabel Schritte
+  reproductionSteps 'Reproduktionsschritte'
+  reproductionOpen 'Öffnen Sie {{url}}'
+  reproductionEnter 'Geben Sie {{expression}} ein'
+  reproductionRunCalculation 'Führen Sie die Berechnung aus'
+  reproductionUseCalculator 'Verwenden Sie den Rechner, bis das Problem auftritt'
+  reproductionClickReportIssue 'Klicken Sie auf Problem melden'
   errorLabel Fehler
   description Beschreibung
   descriptionPlaceholder 'Bitte beschreiben Sie das aufgetretene Problem'

--- a/web/src/i18n/locales/en.lino
+++ b/web/src/i18n/locales/en.lino
@@ -15,6 +15,8 @@ result:
   timezoneConversions 'Timezone conversions'
   localTime 'Local time'
   utcTime 'UTC time'
+  notations 'Decimal Notations'
+  plot 'Function Plot'
 examples:
   title 'Try these examples:'
 errors:
@@ -36,6 +38,7 @@ errors:
   unknownFunction 'Unknown function: {{name}}'
   invalidFunctionArgs 'Invalid arguments for function "{{function}}": {{reason}}'
   domainError 'Domain error: {{message}}'
+  unknownError 'Unknown error'
 footer:
   poweredBy 'Powered by Rust + WebAssembly'
   viewOnGitHub 'View on GitHub'
@@ -57,8 +60,15 @@ share:
   copied Copied!
 steps:
   inputExpression 'Input expression: {{expression}}'
+  input 'Input: {{expression}}'
   literalValue 'Literal value: {{value}}'
   dateTimeValue 'DateTime value: {{value}}'
+  utcEquivalent 'UTC equivalent: {{value}}'
+  timeUntil 'Time until: {{duration}}'
+  timeSince 'Time since: {{duration}} ago'
+  currentTime 'Current time: {{time}}'
+  timeUntilTarget 'Time until {{target}}: {{duration}}'
+  timeSinceTarget 'Time since {{target}}: {{duration}} ago'
   compute 'Compute: {{left}} {{op}} {{right}}'
   equals '= {{value}}'
   negate 'Negate: -{{value}} = {{result}}'
@@ -73,6 +83,13 @@ steps:
   result 'Result: {{value}}'
   finalResult 'Final result: {{value}}'
   exchangeRate 'Exchange rate: 1 {{from}} = {{rate}} {{to}} (source: {{source}}, date: {{date}})'
+  convert 'Convert: {{value}} to {{unit}}'
+  indefiniteIntegral 'Indefinite integral: ∫ {{integrand}} d{{variable}}'
+  computedSymbolicResult 'Computed symbolic result'
+  solveLinearEquation 'Solve linear equation:'
+  solution 'Solution: {{value}}'
+  checkEquality 'Check equality:'
+  compare 'Compare: {{left}} = {{right}}'
 issueReport:
   environment Environment
   version Version
@@ -86,7 +103,14 @@ issueReport:
   resultSection Result
   resultLabel Result
   linksNotation 'Links Notation'
+  alternativeInterpretations 'Alternative interpretations'
   stepsLabel Steps
+  reproductionSteps 'Reproduction Steps'
+  reproductionOpen 'Open {{url}}'
+  reproductionEnter 'Enter {{expression}}'
+  reproductionRunCalculation 'Run the calculation'
+  reproductionUseCalculator 'Use the calculator until the issue occurs'
+  reproductionClickReportIssue 'Click Report Issue'
   errorLabel Error
   description Description
   descriptionPlaceholder 'Please describe the issue you encountered'

--- a/web/src/i18n/locales/fr.lino
+++ b/web/src/i18n/locales/fr.lino
@@ -15,6 +15,8 @@ result:
   timezoneConversions 'Conversions de fuseau horaire'
   localTime 'Heure locale'
   utcTime 'Heure UTC'
+  notations 'Notations décimales'
+  plot 'Graphe de fonction'
 examples:
   title 'Essayez ces exemples :'
 errors:
@@ -36,6 +38,7 @@ errors:
   unknownFunction 'Fonction inconnue : {{name}}'
   invalidFunctionArgs 'Arguments invalides pour la fonction "{{function}}" : {{reason}}'
   domainError 'Erreur de domaine : {{message}}'
+  unknownError 'Erreur inconnue'
 footer:
   poweredBy 'Propulsé par Rust + WebAssembly'
   viewOnGitHub 'Voir sur GitHub'
@@ -57,8 +60,15 @@ share:
   copied 'Copié !'
 steps:
   inputExpression "Expression d'entrée : {{expression}}"
+  input 'Entrée : {{expression}}'
   literalValue 'Valeur littérale : {{value}}'
   dateTimeValue 'Valeur date/heure : {{value}}'
+  utcEquivalent 'Équivalent UTC : {{value}}'
+  timeUntil "Temps restant : {{duration}}"
+  timeSince 'Temps écoulé : {{duration}}'
+  currentTime 'Heure actuelle : {{time}}'
+  timeUntilTarget "Temps restant jusqu'à {{target}} : {{duration}}"
+  timeSinceTarget 'Temps écoulé depuis {{target}} : {{duration}}'
   compute 'Calculer : {{left}} {{op}} {{right}}'
   equals '= {{value}}'
   negate 'Négation : -{{value}} = {{result}}'
@@ -73,6 +83,13 @@ steps:
   result 'Résultat : {{value}}'
   finalResult 'Résultat final : {{value}}'
   exchangeRate 'Taux de change : 1 {{from}} = {{rate}} {{to}} (source : {{source}}, date : {{date}})'
+  convert 'Convertir : {{value}} en {{unit}}'
+  indefiniteIntegral 'Intégrale indéfinie : ∫ {{integrand}} d{{variable}}'
+  computedSymbolicResult 'Résultat symbolique calculé'
+  solveLinearEquation "Résoudre l'équation linéaire :"
+  solution 'Solution : {{value}}'
+  checkEquality "Vérifier l'égalité :"
+  compare 'Comparer : {{left}} = {{right}}'
 issueReport:
   environment Environnement
   version Version
@@ -86,7 +103,14 @@ issueReport:
   resultSection Résultat
   resultLabel Résultat
   linksNotation 'Notation Links'
+  alternativeInterpretations 'Interprétations alternatives'
   stepsLabel Étapes
+  reproductionSteps 'Étapes de reproduction'
+  reproductionOpen 'Ouvrez {{url}}'
+  reproductionEnter 'Saisissez {{expression}}'
+  reproductionRunCalculation 'Lancez le calcul'
+  reproductionUseCalculator "Utilisez la calculatrice jusqu'à ce que le problème se produise"
+  reproductionClickReportIssue 'Cliquez sur Signaler un problème'
   errorLabel Erreur
   description Description
   descriptionPlaceholder 'Veuillez décrire le problème rencontré'

--- a/web/src/i18n/locales/hi.lino
+++ b/web/src/i18n/locales/hi.lino
@@ -15,6 +15,8 @@ result:
   timezoneConversions 'समय क्षेत्र रूपांतरण'
   localTime 'स्थानीय समय'
   utcTime 'UTC समय'
+  notations 'दशमलव नोटेशन'
+  plot 'फ़ंक्शन ग्राफ़'
 examples:
   title 'इन उदाहरणों को आज़माएं:'
 errors:
@@ -36,6 +38,7 @@ errors:
   unknownFunction 'अज्ञात फ़ंक्शन: {{name}}'
   invalidFunctionArgs 'फ़ंक्शन "{{function}}" के लिए अमान्य तर्क: {{reason}}'
   domainError 'डोमेन त्रुटि: {{message}}'
+  unknownError 'अज्ञात त्रुटि'
 footer:
   poweredBy 'Rust + WebAssembly द्वारा संचालित'
   viewOnGitHub 'GitHub पर देखें'
@@ -57,8 +60,15 @@ share:
   copied 'कॉपी किया गया!'
 steps:
   inputExpression 'इनपुट अभिव्यक्ति: {{expression}}'
+  input 'इनपुट: {{expression}}'
   literalValue 'शाब्दिक मान: {{value}}'
   dateTimeValue 'दिनांक/समय मान: {{value}}'
+  utcEquivalent 'UTC समतुल्य: {{value}}'
+  timeUntil 'शेष समय: {{duration}}'
+  timeSince 'बीता समय: {{duration}}'
+  currentTime 'वर्तमान समय: {{time}}'
+  timeUntilTarget '{{target}} तक शेष समय: {{duration}}'
+  timeSinceTarget '{{target}} से बीता समय: {{duration}}'
   compute 'गणना: {{left}} {{op}} {{right}}'
   equals '= {{value}}'
   negate 'नकारात्मक: -{{value}} = {{result}}'
@@ -73,6 +83,13 @@ steps:
   result 'परिणाम: {{value}}'
   finalResult 'अंतिम परिणाम: {{value}}'
   exchangeRate 'विनिमय दर: 1 {{from}} = {{rate}} {{to}} (स्रोत: {{source}}, तारीख: {{date}})'
+  convert 'रूपांतरित करें: {{value}} को {{unit}} में'
+  indefiniteIntegral 'अनिश्चित समाकल: ∫ {{integrand}} d{{variable}}'
+  computedSymbolicResult 'प्रतीकात्मक परिणाम की गणना की गई'
+  solveLinearEquation 'रेखीय समीकरण हल करें:'
+  solution 'हल: {{value}}'
+  checkEquality 'समानता जाँचें:'
+  compare 'तुलना करें: {{left}} = {{right}}'
 issueReport:
   environment वातावरण
   version संस्करण
@@ -86,7 +103,14 @@ issueReport:
   resultSection परिणाम
   resultLabel परिणाम
   linksNotation 'लिंक्स नोटेशन'
+  alternativeInterpretations 'वैकल्पिक व्याख्याएँ'
   stepsLabel चरण
+  reproductionSteps 'पुनरुत्पादन चरण'
+  reproductionOpen '{{url}} खोलें'
+  reproductionEnter '{{expression}} दर्ज करें'
+  reproductionRunCalculation 'गणना चलाएँ'
+  reproductionUseCalculator 'समस्या होने तक कैलकुलेटर का उपयोग करें'
+  reproductionClickReportIssue 'समस्या की रिपोर्ट करें पर क्लिक करें'
   errorLabel त्रुटि
   description विवरण
   descriptionPlaceholder 'कृपया आपको जो समस्या आई उसका वर्णन करें'

--- a/web/src/i18n/locales/ru.lino
+++ b/web/src/i18n/locales/ru.lino
@@ -10,11 +10,13 @@ result:
   calculating Вычисление...
   loading 'Загрузка движка калькулятора...'
   placeholder 'Введите выражение выше'
-  linksNotation 'Links Notation'
+  linksNotation 'Нотация ссылок'
   steps Шаги
   timezoneConversions 'Преобразования часовых поясов'
   localTime 'Местное время'
   utcTime 'Время UTC'
+  notations 'Десятичные нотации'
+  plot 'График функции'
 examples:
   title 'Попробуйте эти примеры:'
 errors:
@@ -36,6 +38,7 @@ errors:
   unknownFunction 'Неизвестная функция: {{name}}'
   invalidFunctionArgs 'Неверные аргументы для функции "{{function}}": {{reason}}'
   domainError 'Ошибка области определения: {{message}}'
+  unknownError 'Неизвестная ошибка'
 footer:
   poweredBy 'На базе Rust + WebAssembly'
   viewOnGitHub 'Смотреть на GitHub'
@@ -57,8 +60,15 @@ share:
   copied Скопировано!
 steps:
   inputExpression 'Входное выражение: {{expression}}'
+  input 'Ввод: {{expression}}'
   literalValue 'Литеральное значение: {{value}}'
   dateTimeValue 'Значение даты/времени: {{value}}'
+  utcEquivalent 'Эквивалент UTC: {{value}}'
+  timeUntil 'До события: {{duration}}'
+  timeSince 'С момента события: {{duration}} назад'
+  currentTime 'Текущее время: {{time}}'
+  timeUntilTarget 'До {{target}}: {{duration}}'
+  timeSinceTarget 'С момента {{target}}: {{duration}} назад'
   compute 'Вычислить: {{left}} {{op}} {{right}}'
   equals '= {{value}}'
   negate 'Отрицание: -{{value}} = {{result}}'
@@ -73,6 +83,13 @@ steps:
   result 'Результат: {{value}}'
   finalResult 'Итоговый результат: {{value}}'
   exchangeRate 'Курс обмена: 1 {{from}} = {{rate}} {{to}} (источник: {{source}}, дата: {{date}})'
+  convert 'Преобразовать: {{value}} в {{unit}}'
+  indefiniteIntegral 'Неопределённый интеграл: ∫ {{integrand}} d{{variable}}'
+  computedSymbolicResult 'Вычислен символьный результат'
+  solveLinearEquation 'Решить линейное уравнение:'
+  solution 'Решение: {{value}}'
+  checkEquality 'Проверить равенство:'
+  compare 'Сравнить: {{left}} = {{right}}'
 issueReport:
   environment Окружение
   version Версия
@@ -85,8 +102,15 @@ issueReport:
   input Ввод
   resultSection Результат
   resultLabel Результат
-  linksNotation 'Links Notation'
+  linksNotation 'Нотация ссылок'
+  alternativeInterpretations 'Альтернативные интерпретации'
   stepsLabel Шаги
+  reproductionSteps 'Шаги воспроизведения'
+  reproductionOpen 'Откройте {{url}}'
+  reproductionEnter 'Введите {{expression}}'
+  reproductionRunCalculation 'Запустите вычисление'
+  reproductionUseCalculator 'Используйте калькулятор до возникновения проблемы'
+  reproductionClickReportIssue 'Нажмите Сообщить о проблеме'
   errorLabel Ошибка
   description Описание
   descriptionPlaceholder 'Пожалуйста, опишите возникшую проблему'

--- a/web/src/i18n/locales/zh.lino
+++ b/web/src/i18n/locales/zh.lino
@@ -15,6 +15,8 @@ result:
   timezoneConversions 时区转换
   localTime 本地时间
   utcTime 'UTC 时间'
+  notations 十进制表示法
+  plot 函数图
 examples:
   title 试试这些示例：
 errors:
@@ -36,6 +38,7 @@ errors:
   unknownFunction '未知函数：{{name}}'
   invalidFunctionArgs '函数 "{{function}}" 的参数无效：{{reason}}'
   domainError '域错误：{{message}}'
+  unknownError 未知错误
 footer:
   poweredBy '由 Rust + WebAssembly 驱动'
   viewOnGitHub '在 GitHub 上查看'
@@ -57,8 +60,15 @@ share:
   copied 已复制！
 steps:
   inputExpression '输入表达式：{{expression}}'
+  input '输入：{{expression}}'
   literalValue '字面值：{{value}}'
   dateTimeValue '日期时间值：{{value}}'
+  utcEquivalent 'UTC 等效时间：{{value}}'
+  timeUntil '剩余时间：{{duration}}'
+  timeSince '已经过：{{duration}}'
+  currentTime '当前时间：{{time}}'
+  timeUntilTarget '距离 {{target}}：{{duration}}'
+  timeSinceTarget '自 {{target}} 已经过：{{duration}}'
   compute '计算：{{left}} {{op}} {{right}}'
   equals '= {{value}}'
   negate '取反：-{{value}} = {{result}}'
@@ -73,6 +83,13 @@ steps:
   result '结果：{{value}}'
   finalResult '最终结果：{{value}}'
   exchangeRate '汇率：1 {{from}} = {{rate}} {{to}}（来源：{{source}}，日期：{{date}}）'
+  convert '转换：{{value}} 到 {{unit}}'
+  indefiniteIntegral '不定积分：∫ {{integrand}} d{{variable}}'
+  computedSymbolicResult 已计算符号结果
+  solveLinearEquation 求解线性方程：
+  solution '解：{{value}}'
+  checkEquality 检查相等性：
+  compare '比较：{{left}} = {{right}}'
 issueReport:
   environment 环境
   version 版本
@@ -86,7 +103,14 @@ issueReport:
   resultSection 结果
   resultLabel 结果
   linksNotation 链接表示法
+  alternativeInterpretations 替代解释
   stepsLabel 步骤
+  reproductionSteps 复现步骤
+  reproductionOpen '打开 {{url}}'
+  reproductionEnter '输入 {{expression}}'
+  reproductionRunCalculation 运行计算
+  reproductionUseCalculator 使用计算器直到问题出现
+  reproductionClickReportIssue 点击报告问题
   errorLabel 错误
   description 描述
   descriptionPlaceholder 请描述您遇到的问题

--- a/web/src/utils/index.ts
+++ b/web/src/utils/index.ts
@@ -1,1 +1,2 @@
+export * from './localizeCalculation';
 export * from './reportIssue';

--- a/web/src/utils/localizeCalculation.test.ts
+++ b/web/src/utils/localizeCalculation.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import type { TFunction } from 'i18next';
+import type { CalculationResult } from '../types';
+import { localizeCalculationSteps, translateCalculationStep } from './localizeCalculation';
+
+function makeTranslator(translations: Record<string, string>): TFunction {
+  return ((key: string, options?: Record<string, unknown>) => {
+    let value = translations[key] || String(options?.defaultValue || key);
+    if (options) {
+      Object.entries(options).forEach(([name, replacement]) => {
+        value = value.replace(`{{${name}}}`, String(replacement));
+      });
+    }
+    return value;
+  }) as TFunction;
+}
+
+describe('calculation step localization', () => {
+  const ruT = makeTranslator({
+    'steps.inputExpression': 'Входное выражение: {{expression}}',
+    'steps.literalValue': 'Литеральное значение: {{value}}',
+    'steps.compute': 'Вычислить: {{left}} {{op}} {{right}}',
+    'steps.equals': '= {{value}}',
+    'steps.evaluateGroup': 'Вычислить сгруппированное выражение:',
+    'steps.finalResult': 'Итоговый результат: {{value}}',
+  });
+
+  it('should translate raw arithmetic steps from issue 171', () => {
+    const steps = [
+      'Input expression: (((1 / 2) + 1) / 4)',
+      'Evaluate grouped expression:',
+      'Literal value: 1',
+      'Literal value: 2',
+      'Compute: 1 / 2',
+      '= 0.5',
+      'Final result: 0.375',
+    ];
+
+    expect(steps.map(step => translateCalculationStep(ruT, step))).toEqual([
+      'Входное выражение: (((1 / 2) + 1) / 4)',
+      'Вычислить сгруппированное выражение:',
+      'Литеральное значение: 1',
+      'Литеральное значение: 2',
+      'Вычислить: 1 / 2',
+      '= 0.5',
+      'Итоговый результат: 0.375',
+    ]);
+  });
+
+  it('should prefer structured i18n step metadata when present', () => {
+    const result: CalculationResult = {
+      result: '5',
+      lino_interpretation: '((2) + (3))',
+      steps: ['Input expression: 2 + 3'],
+      steps_i18n: [
+        {
+          key: 'steps.inputExpression',
+          params: { expression: '2 + 3' },
+          text: 'Input expression: 2 + 3',
+        },
+      ],
+      success: true,
+    };
+
+    expect(localizeCalculationSteps(ruT, result)).toEqual(['Входное выражение: 2 + 3']);
+  });
+});

--- a/web/src/utils/localizeCalculation.ts
+++ b/web/src/utils/localizeCalculation.ts
@@ -1,0 +1,284 @@
+import type { TFunction } from 'i18next';
+import type { CalculationResult, CalculationStep } from '../types';
+
+type StepParams = Record<string, string>;
+
+interface ParsedCalculationStep {
+  key: string;
+  params?: StepParams;
+}
+
+function translateStepKey(
+  t: TFunction,
+  key: string,
+  params: StepParams | undefined,
+  fallback: string
+): string {
+  const translated = t(key, {
+    ...(params || {}),
+    defaultValue: fallback,
+  });
+
+  return translated === key ? fallback : String(translated);
+}
+
+function parseRawCalculationStep(step: string): ParsedCalculationStep | null {
+  if (step === 'Evaluate grouped expression:') {
+    return { key: 'steps.evaluateGroup' };
+  }
+  if (step === 'Computed symbolic result') {
+    return { key: 'steps.computedSymbolicResult' };
+  }
+  if (step === 'Solve linear equation:') {
+    return { key: 'steps.solveLinearEquation' };
+  }
+  if (step === 'Check equality:') {
+    return { key: 'steps.checkEquality' };
+  }
+
+  const matchers: Array<{
+    regex: RegExp;
+    build: (match: RegExpMatchArray) => ParsedCalculationStep;
+  }> = [
+    {
+      regex: /^Input expression: (.+)$/,
+      build: match => ({
+        key: 'steps.inputExpression',
+        params: { expression: match[1] },
+      }),
+    },
+    {
+      regex: /^Input: (.+)$/,
+      build: match => ({
+        key: 'steps.input',
+        params: { expression: match[1] },
+      }),
+    },
+    {
+      regex: /^Literal value: (.+)$/,
+      build: match => ({
+        key: 'steps.literalValue',
+        params: { value: match[1] },
+      }),
+    },
+    {
+      regex: /^DateTime value: (.+)$/,
+      build: match => ({
+        key: 'steps.dateTimeValue',
+        params: { value: match[1] },
+      }),
+    },
+    {
+      regex: /^UTC equivalent: (.+)$/,
+      build: match => ({
+        key: 'steps.utcEquivalent',
+        params: { value: match[1] },
+      }),
+    },
+    {
+      regex: /^Time until: (.+)$/,
+      build: match => ({
+        key: 'steps.timeUntil',
+        params: { duration: match[1] },
+      }),
+    },
+    {
+      regex: /^Time since: (.+) ago$/,
+      build: match => ({
+        key: 'steps.timeSince',
+        params: { duration: match[1] },
+      }),
+    },
+    {
+      regex: /^Current time: (.+)$/,
+      build: match => ({
+        key: 'steps.currentTime',
+        params: { time: match[1] },
+      }),
+    },
+    {
+      regex: /^Time until (.+): (.+)$/,
+      build: match => ({
+        key: 'steps.timeUntilTarget',
+        params: { target: match[1], duration: match[2] },
+      }),
+    },
+    {
+      regex: /^Time since (.+): (.+) ago$/,
+      build: match => ({
+        key: 'steps.timeSinceTarget',
+        params: { target: match[1], duration: match[2] },
+      }),
+    },
+    {
+      regex: /^Compute: (.+) \^ (.+)$/,
+      build: match => ({
+        key: 'steps.computePower',
+        params: { base: match[1], exponent: match[2] },
+      }),
+    },
+    {
+      regex: /^Compute: (.+) ([+\-*/%]) (.+)$/,
+      build: match => ({
+        key: 'steps.compute',
+        params: { left: match[1], op: match[2], right: match[3] },
+      }),
+    },
+    {
+      regex: /^= (.+)$/,
+      build: match => ({
+        key: 'steps.equals',
+        params: { value: match[1] },
+      }),
+    },
+    {
+      regex: /^Negate: -(.+) = (.+)$/,
+      build: match => ({
+        key: 'steps.negate',
+        params: { value: match[1], result: match[2] },
+      }),
+    },
+    {
+      regex: /^At time: (.+)$/,
+      build: match => ({
+        key: 'steps.atTime',
+        params: { time: match[1] },
+      }),
+    },
+    {
+      regex: /^Call function: ([^(]+)\((.*)\)$/,
+      build: match => ({
+        key: 'steps.callFunction',
+        params: { name: match[1], args: match[2] },
+      }),
+    },
+    {
+      regex: /^Numerical integration: (.+)\(\.\.\.\)$/,
+      build: match => ({
+        key: 'steps.numericalIntegration',
+        params: { name: match[1] },
+      }),
+    },
+    {
+      regex: /^Parse first datetime: (.+)$/,
+      build: match => ({
+        key: 'steps.parseFirstDatetime',
+        params: { datetime: match[1] },
+      }),
+    },
+    {
+      regex: /^Parse second datetime: (.+)$/,
+      build: match => ({
+        key: 'steps.parseSecondDatetime',
+        params: { datetime: match[1] },
+      }),
+    },
+    {
+      regex: /^Calculate difference: (.+) - (.+)$/,
+      build: match => ({
+        key: 'steps.calculateDifference',
+        params: { dt1: match[1], dt2: match[2] },
+      }),
+    },
+    {
+      regex: /^Result: (.+)$/,
+      build: match => ({
+        key: 'steps.result',
+        params: { value: match[1] },
+      }),
+    },
+    {
+      regex: /^Final result: (.+)$/,
+      build: match => ({
+        key: 'steps.finalResult',
+        params: { value: match[1] },
+      }),
+    },
+    {
+      regex: /^Exchange rate: 1 ([A-Za-z0-9]+) = (.+) ([A-Za-z0-9]+) \(source: (.+), date: (.+)\)$/,
+      build: match => ({
+        key: 'steps.exchangeRate',
+        params: {
+          from: match[1],
+          rate: match[2],
+          to: match[3],
+          source: match[4],
+          date: match[5],
+        },
+      }),
+    },
+    {
+      regex: /^Convert: (.+) to (.+)$/,
+      build: match => ({
+        key: 'steps.convert',
+        params: { value: match[1], unit: match[2] },
+      }),
+    },
+    {
+      regex: /^Indefinite integral: ∫ (.+) d(.+)$/,
+      build: match => ({
+        key: 'steps.indefiniteIntegral',
+        params: { integrand: match[1], variable: match[2] },
+      }),
+    },
+    {
+      regex: /^Solution: (.+)$/,
+      build: match => ({
+        key: 'steps.solution',
+        params: { value: match[1] },
+      }),
+    },
+    {
+      regex: /^Compare: (.+) = (.+)$/,
+      build: match => ({
+        key: 'steps.compare',
+        params: { left: match[1], right: match[2] },
+      }),
+    },
+  ];
+
+  for (const matcher of matchers) {
+    const match = step.match(matcher.regex);
+    if (match) {
+      return matcher.build(match);
+    }
+  }
+
+  return null;
+}
+
+export function translateCalculationStep(
+  t: TFunction,
+  step: string | CalculationStep
+): string {
+  if (typeof step !== 'string') {
+    if (!step.key) {
+      return step.text;
+    }
+
+    return translateStepKey(t, step.key, step.params, step.text);
+  }
+
+  const parsed = parseRawCalculationStep(step);
+  if (!parsed) {
+    return step;
+  }
+
+  return translateStepKey(t, parsed.key, parsed.params, step);
+}
+
+export function localizeCalculationSteps(
+  t: TFunction,
+  result: Pick<CalculationResult, 'steps' | 'steps_i18n'>
+): string[] {
+  if (result.steps_i18n?.length === result.steps.length) {
+    return result.steps_i18n.map((step, index) =>
+      translateCalculationStep(t, {
+        ...step,
+        text: step.text || result.steps[index],
+      })
+    );
+  }
+
+  return result.steps.map(step => translateCalculationStep(t, step));
+}

--- a/web/src/utils/reportIssue.test.ts
+++ b/web/src/utils/reportIssue.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { generateIssueReport, generateIssueUrl, type PageState } from './reportIssue';
+import { generateIssueReport, generateIssueUrl, type IssueReportTranslator, type PageState } from './reportIssue';
 
 describe('reportIssue utilities', () => {
   const basePageState: PageState = {
@@ -150,6 +150,23 @@ describe('reportIssue utilities', () => {
   describe('generateIssueUrl', () => {
     // Helper to decode URL with + signs converted to spaces (URLSearchParams encoding)
     const decodeUrl = (url: string) => decodeURIComponent(url.replace(/\+/g, ' '));
+    const getIssueBody = (url: string) => new URL(url).searchParams.get('body') || '';
+
+    function makeTranslator(translations: Record<string, string>): IssueReportTranslator {
+      return ((key: string, fallbackOrOptions?: string | Record<string, unknown>) => {
+        const fallback =
+          typeof fallbackOrOptions === 'string'
+            ? fallbackOrOptions
+            : String(fallbackOrOptions?.defaultValue || key);
+        let value = translations[key] || fallback;
+        if (fallbackOrOptions && typeof fallbackOrOptions === 'object') {
+          Object.entries(fallbackOrOptions).forEach(([name, replacement]) => {
+            value = value.replace(`{{${name}}}`, String(replacement));
+          });
+        }
+        return value;
+      }) as IssueReportTranslator;
+    }
 
     it('should generate issue URL for a caller-supplied repository and report payload', () => {
       const url = generateIssueUrl({
@@ -237,6 +254,56 @@ describe('reportIssue utilities', () => {
       expect(url).toContain('title=');
       expect(url).toContain('body=');
       expect(url).toContain('labels=bug');
+    });
+
+    it('should localize generated reproduction steps when a translator is provided', () => {
+      const t = makeTranslator({
+        'issueReport.environment': 'Окружение',
+        'issueReport.version': 'Версия',
+        'issueReport.url': 'URL',
+        'issueReport.userAgent': 'Браузер',
+        'issueReport.theme': 'Тема',
+        'issueReport.language': 'Язык',
+        'issueReport.wasmReady': 'WASM готов',
+        'issueReport.timestamp': 'Время',
+        'issueReport.input': 'Ввод',
+        'issueReport.resultSection': 'Результат',
+        'issueReport.resultLabel': 'Результат',
+        'issueReport.linksNotation': 'Нотация ссылок',
+        'issueReport.alternativeInterpretations': 'Альтернативные интерпретации',
+        'issueReport.stepsLabel': 'Шаги',
+        'issueReport.reproductionSteps': 'Шаги воспроизведения',
+        'issueReport.reproductionOpen': 'Откройте {{url}}',
+        'issueReport.reproductionEnter': 'Введите {{expression}}',
+        'issueReport.reproductionRunCalculation': 'Запустите вычисление',
+        'issueReport.reproductionUseCalculator': 'Используйте калькулятор до возникновения проблемы',
+        'issueReport.reproductionClickReportIssue': 'Нажмите Сообщить о проблеме',
+        'issueReport.errorLabel': 'Ошибка',
+        'issueReport.description': 'Описание',
+        'issueReport.descriptionPlaceholder': 'Опишите возникшую проблему',
+        'issueReport.issueTitle': 'Проблема с выражением: {{expression}}',
+        'common.yes': 'Да',
+        'common.no': 'Нет',
+        'common.unknown': 'Неизвестно',
+        'errors.unknownError': 'Неизвестная ошибка',
+      });
+      const url = generateIssueUrl(
+        {
+          ...basePageState,
+          expression: '1/2 + 1/4',
+          language: 'ru',
+        },
+        t
+      );
+      const body = getIssueBody(url);
+
+      expect(body).toContain('## Шаги воспроизведения');
+      expect(body).toContain('1. Откройте https://example.com/calculator/');
+      expect(body).toContain('2. Введите 1/2 + 1/4');
+      expect(body).toContain('3. Запустите вычисление');
+      expect(body).toContain('4. Нажмите Сообщить о проблеме');
+      expect(body).not.toContain('Run the calculation');
+      expect(body).not.toContain('Click Report Issue');
     });
 
     it('should include expression in title when provided', () => {

--- a/web/src/utils/reportIssue.ts
+++ b/web/src/utils/reportIssue.ts
@@ -49,6 +49,11 @@ export interface IssueReportLabels {
   alternativeInterpretations: string;
   stepsLabel: string;
   reproductionSteps: string;
+  reproductionOpen: string;
+  reproductionEnter: string;
+  reproductionRunCalculation: string;
+  reproductionUseCalculator: string;
+  reproductionClickReportIssue: string;
   errorLabel: string;
   description: string;
   descriptionPlaceholder: string;
@@ -114,6 +119,11 @@ export function getDefaultLabels(): IssueReportLabels {
     alternativeInterpretations: 'Alternative interpretations',
     stepsLabel: 'Steps',
     reproductionSteps: 'Reproduction Steps',
+    reproductionOpen: 'Open {{url}}',
+    reproductionEnter: 'Enter {{expression}}',
+    reproductionRunCalculation: 'Run the calculation',
+    reproductionUseCalculator: 'Use the calculator until the issue occurs',
+    reproductionClickReportIssue: 'Click Report Issue',
     errorLabel: 'Error',
     description: 'Description',
     descriptionPlaceholder: 'Please describe the issue you encountered',
@@ -147,6 +157,20 @@ export function getLabelsFromI18n(t: IssueReportTranslator): IssueReportLabels {
     ),
     stepsLabel: t('issueReport.stepsLabel', 'Steps'),
     reproductionSteps: t('issueReport.reproductionSteps', 'Reproduction Steps'),
+    reproductionOpen: t('issueReport.reproductionOpen', 'Open {{url}}'),
+    reproductionEnter: t('issueReport.reproductionEnter', 'Enter {{expression}}'),
+    reproductionRunCalculation: t(
+      'issueReport.reproductionRunCalculation',
+      'Run the calculation'
+    ),
+    reproductionUseCalculator: t(
+      'issueReport.reproductionUseCalculator',
+      'Use the calculator until the issue occurs'
+    ),
+    reproductionClickReportIssue: t(
+      'issueReport.reproductionClickReportIssue',
+      'Click Report Issue'
+    ),
     errorLabel: t('issueReport.errorLabel', 'Error'),
     description: t('issueReport.description', 'Description'),
     descriptionPlaceholder: t(
@@ -240,17 +264,29 @@ function normalizeResult(result: CalculationResultLike | IssueReportResult | nul
   };
 }
 
-function getDefaultReproductionSteps(state: PageState): string[] {
-  const steps = [`Open ${state.url}`];
+function interpolateTemplate(template: string, values: Record<string, string>): string {
+  return template.replace(/\{\{([^}]+)\}\}/g, (match, key) => values[key] || match);
+}
+
+function getDefaultReproductionSteps(state: PageState, labels: IssueReportLabels): string[] {
+  const steps = [
+    interpolateTemplate(labels.reproductionOpen, {
+      url: state.url,
+    }),
+  ];
 
   if (state.expression) {
-    steps.push(`Enter ${state.expression}`);
-    steps.push('Run the calculation');
+    steps.push(
+      interpolateTemplate(labels.reproductionEnter, {
+        expression: state.expression,
+      })
+    );
+    steps.push(labels.reproductionRunCalculation);
   } else {
-    steps.push('Use the calculator until the issue occurs');
+    steps.push(labels.reproductionUseCalculator);
   }
 
-  steps.push('Click Report Issue');
+  steps.push(labels.reproductionClickReportIssue);
   return steps;
 }
 
@@ -258,10 +294,12 @@ function pageStateToReportOptions(
   state: PageState,
   labels?: IssueReportLabels
 ): GenerateIssueReportOptions {
+  const reportLabels = labels || getDefaultLabels();
+
   return {
     input: state.expression,
     result: normalizeResult(state.result),
-    reproductionSteps: getDefaultReproductionSteps(state),
+    reproductionSteps: getDefaultReproductionSteps(state, reportLabels),
     environment: {
       version: state.version,
       url: state.url,
@@ -271,7 +309,7 @@ function pageStateToReportOptions(
       wasmReady: state.wasmReady,
       timestamp: state.timestamp,
     },
-    labels,
+    labels: reportLabels,
   };
 }
 


### PR DESCRIPTION
## Summary
- Localize calculator step output in the UI and in generated issue reports, including raw fallback step strings and structured `steps_i18n` metadata.
- Add missing locale keys for issue-report labels, reproduction steps, result headings, and calculation-step templates across supported languages.
- Run web unit tests in the CI web-build job so translation key and interpolation coverage is checked automatically.

Fixes #171

## Reproduction
1. Set the UI language to Russian.
2. Calculate `1/2 + 1/4`.
3. Open Report Issue.

Before this change, the result/report could include English labels such as `Input expression`, `Alternative interpretations`, and `Reproduction Steps`. After this change, known calculation-step prefixes and issue-report sections are localized for the selected language.

## Tests
- `npm test`
- `npx tsc --noEmit`
- `npm run build`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --verbose`
- `node scripts/check-file-size.mjs`
- `node scripts/check-changelog-fragment.mjs`
