### PR TITLE
Support placeholder, symbolic, and polynomial equations

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-06-04T20:00:11.545Z for PR creation at branch issue-168-9b64bc6696af for issue https://github.com/link-assistant/calculator/issues/168
 # Updated: 2026-06-08T17:17:25.941Z
+# Updated: 2026-06-12T08:30:29.882Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-04T20:00:11.545Z for PR creation at branch issue-168-9b64bc6696af for issue https://github.com/link-assistant/calculator/issues/168
-# Updated: 2026-06-08T17:17:25.941Z
-# Updated: 2026-06-12T08:30:29.882Z

--- a/changelog.d/20260612_083500_issue_174_placeholder_equations.md
+++ b/changelog.d/20260612_083500_issue_174_placeholder_equations.md
@@ -8,3 +8,6 @@ bump: minor
   derivation steps.
 - Support symbolic solutions for linear equations with multiple variables, such
   as `x + y = 10` -> `x = 10 - y`, including detailed step-by-step derivations.
+- Support exact real rational roots for single-variable polynomial equations
+  with nonnegative integer powers, including quadratic and higher-power cases
+  such as `x^2 = 4` -> `x = -2 or x = 2`.

--- a/changelog.d/20260612_083500_issue_174_placeholder_equations.md
+++ b/changelog.d/20260612_083500_issue_174_placeholder_equations.md
@@ -6,3 +6,5 @@ bump: minor
 - Support `?` and operand-position `*` as single-unknown placeholders in
   supported linear equations, with structured equation-solution results and
   derivation steps.
+- Support symbolic solutions for linear equations with multiple variables, such
+  as `x + y = 10` -> `x = 10 - y`, including detailed step-by-step derivations.

--- a/changelog.d/20260612_083500_issue_174_placeholder_equations.md
+++ b/changelog.d/20260612_083500_issue_174_placeholder_equations.md
@@ -1,0 +1,8 @@
+---
+bump: minor
+---
+
+### Added
+- Support `?` and operand-position `*` as single-unknown placeholders in
+  supported linear equations, with structured equation-solution results and
+  derivation steps.

--- a/src/grammar/expression_parser.rs
+++ b/src/grammar/expression_parser.rs
@@ -1,12 +1,13 @@
 //! Expression parser that combines all grammars.
 
 use crate::error::CalculatorError;
+use crate::grammar::linear_equation;
 use crate::grammar::token_parser::TokenParser;
 use crate::grammar::{
     evaluate_function, evaluate_indefinite_integral, DateTimeGrammar, Lexer, NumberGrammar,
 };
 use crate::types::{
-    BinaryOp, CurrencyDatabase, DateTime, Decimal, Expression, Rational, Unit, Value, ValueKind,
+    BinaryOp, CurrencyDatabase, DateTime, Decimal, Expression, Rational, Value, ValueKind,
 };
 
 /// Evaluates a power expression, using exact rational arithmetic when possible.
@@ -68,152 +69,6 @@ pub struct ExpressionParser {
     currency_db: CurrencyDatabase,
     /// Current date context for historical currency conversions (set by AtTime expressions).
     current_date_context: Option<DateTime>,
-}
-
-#[derive(Debug, Clone)]
-struct LinearForm {
-    variable: Option<String>,
-    coefficient: Rational,
-    constant: Rational,
-}
-
-impl LinearForm {
-    fn constant(value: Rational) -> Self {
-        Self {
-            variable: None,
-            coefficient: Rational::zero(),
-            constant: value,
-        }
-    }
-
-    fn variable(name: String) -> Self {
-        Self {
-            variable: Some(name),
-            coefficient: Rational::one(),
-            constant: Rational::zero(),
-        }
-    }
-
-    fn from_expression(expr: &Expression) -> Result<Self, CalculatorError> {
-        match expr {
-            Expression::Number { value, unit, .. } => {
-                if *unit != Unit::None {
-                    return Err(Self::unsupported_equation());
-                }
-                Ok(Self::constant(Rational::from_decimal(*value)))
-            }
-            Expression::Variable(name) => Ok(Self::variable(name.clone())),
-            Expression::Binary { left, op, right } => {
-                let left = Self::from_expression(left)?;
-                let right = Self::from_expression(right)?;
-                match op {
-                    BinaryOp::Add => left.add(right),
-                    BinaryOp::Subtract => left.subtract(right),
-                    BinaryOp::Multiply => left.multiply(right),
-                    BinaryOp::Divide => left.divide(right),
-                    BinaryOp::Modulo => Err(Self::unsupported_equation()),
-                }
-            }
-            Expression::Negate(inner) => Ok(Self::from_expression(inner)?.negate()),
-            Expression::Group(inner) => Self::from_expression(inner),
-            Expression::DateTime(_)
-            | Expression::Now
-            | Expression::Until(_)
-            | Expression::AtTime { .. }
-            | Expression::FunctionCall { .. }
-            | Expression::Power { .. }
-            | Expression::IndefiniteIntegral { .. }
-            | Expression::UnitConversion { .. }
-            | Expression::Equality { .. } => Err(Self::unsupported_equation()),
-        }
-    }
-
-    fn add(self, other: Self) -> Result<Self, CalculatorError> {
-        Ok(Self {
-            variable: Self::merge_variable(self.variable, other.variable)?,
-            coefficient: self.coefficient + other.coefficient,
-            constant: self.constant + other.constant,
-        })
-    }
-
-    fn subtract(self, other: Self) -> Result<Self, CalculatorError> {
-        Ok(Self {
-            variable: Self::merge_variable(self.variable, other.variable)?,
-            coefficient: self.coefficient - other.coefficient,
-            constant: self.constant - other.constant,
-        })
-    }
-
-    fn multiply(self, other: Self) -> Result<Self, CalculatorError> {
-        match (self.variable.is_some(), other.variable.is_some()) {
-            (true, true) => Err(CalculatorError::InvalidOperation(
-                "equation is not linear".into(),
-            )),
-            (true, false) => {
-                let scale = other.constant;
-                Ok(Self {
-                    variable: self.variable,
-                    coefficient: self.coefficient * scale.clone(),
-                    constant: self.constant * scale,
-                })
-            }
-            (false, true) => {
-                let scale = self.constant;
-                Ok(Self {
-                    variable: other.variable,
-                    coefficient: other.coefficient * scale.clone(),
-                    constant: other.constant * scale,
-                })
-            }
-            (false, false) => Ok(Self::constant(self.constant * other.constant)),
-        }
-    }
-
-    fn divide(self, other: Self) -> Result<Self, CalculatorError> {
-        if other.variable.is_some() {
-            return Err(CalculatorError::InvalidOperation(
-                "equation has a variable denominator".into(),
-            ));
-        }
-        if other.constant.is_zero() {
-            return Err(CalculatorError::DivisionByZero);
-        }
-
-        Ok(Self {
-            variable: self.variable,
-            coefficient: self.coefficient / other.constant.clone(),
-            constant: self.constant / other.constant,
-        })
-    }
-
-    fn negate(self) -> Self {
-        Self {
-            variable: self.variable,
-            coefficient: -self.coefficient,
-            constant: -self.constant,
-        }
-    }
-
-    fn merge_variable(
-        left: Option<String>,
-        right: Option<String>,
-    ) -> Result<Option<String>, CalculatorError> {
-        match (left, right) {
-            (Some(left), Some(right)) if left == right => Ok(Some(left)),
-            (Some(_), Some(_)) => Err(CalculatorError::InvalidOperation(
-                "equation has more than one variable".into(),
-            )),
-            (Some(variable), None) | (None, Some(variable)) => Ok(Some(variable)),
-            (None, None) => Ok(None),
-        }
-    }
-
-    fn unsupported_equation() -> CalculatorError {
-        CalculatorError::InvalidOperation(
-            "only simple single-variable linear equations with unitless numbers are supported"
-                .into(),
-        )
-    }
 }
 
 impl ExpressionParser {
@@ -315,21 +170,7 @@ impl ExpressionParser {
         left: &Expression,
         right: &Expression,
     ) -> Result<Value, CalculatorError> {
-        let left_form = LinearForm::from_expression(left)?;
-        let right_form = LinearForm::from_expression(right)?;
-        let variable =
-            LinearForm::merge_variable(left_form.variable.clone(), right_form.variable.clone())?
-                .ok_or_else(LinearForm::unsupported_equation)?;
-
-        let coefficient = left_form.coefficient - right_form.coefficient;
-        if coefficient.is_zero() {
-            return Err(CalculatorError::InvalidOperation(
-                "linear equation has no unique solution".into(),
-            ));
-        }
-
-        let value = (right_form.constant - left_form.constant) / coefficient;
-        Ok(Value::equation_solution(variable, value))
+        Ok(linear_equation::solve(left, right)?.to_value())
     }
 
     /// Evaluates an expression with step-by-step tracking.
@@ -709,7 +550,9 @@ impl ExpressionParser {
                     || Self::expression_contains_variable(right)
                 {
                     steps.push("Solve linear equation:".to_string());
-                    let result = Self::solve_linear_equation(left, right)?;
+                    let solution = linear_equation::solve(left, right)?;
+                    steps.extend(solution.derivation_steps());
+                    let result = solution.to_value();
                     steps.push(format!("Solution: {}", result.to_display_string()));
                     return Ok(result);
                 }

--- a/src/grammar/expression_parser.rs
+++ b/src/grammar/expression_parser.rs
@@ -2,6 +2,7 @@
 
 use crate::error::CalculatorError;
 use crate::grammar::linear_equation;
+use crate::grammar::polynomial_equation;
 use crate::grammar::token_parser::TokenParser;
 use crate::grammar::{
     evaluate_function, evaluate_indefinite_integral, DateTimeGrammar, Lexer, NumberGrammar,
@@ -166,11 +167,12 @@ impl ExpressionParser {
         }
     }
 
-    fn solve_linear_equation(
-        left: &Expression,
-        right: &Expression,
-    ) -> Result<Value, CalculatorError> {
-        Ok(linear_equation::solve(left, right)?.to_value())
+    fn solve_equation(left: &Expression, right: &Expression) -> Result<Value, CalculatorError> {
+        if let Ok(solution) = linear_equation::solve(left, right) {
+            return Ok(solution.to_value());
+        }
+
+        Ok(polynomial_equation::solve(left, right)?.to_value())
     }
 
     /// Evaluates an expression with step-by-step tracking.
@@ -311,7 +313,7 @@ impl ExpressionParser {
                 if Self::expression_contains_variable(left)
                     || Self::expression_contains_variable(right)
                 {
-                    return Self::solve_linear_equation(left, right);
+                    return Self::solve_equation(left, right);
                 }
 
                 let left_val = self.evaluate_expr(left)?;
@@ -549,10 +551,16 @@ impl ExpressionParser {
                 if Self::expression_contains_variable(left)
                     || Self::expression_contains_variable(right)
                 {
-                    steps.push("Solve linear equation:".to_string());
-                    let solution = linear_equation::solve(left, right)?;
-                    steps.extend(solution.derivation_steps());
-                    let result = solution.to_value();
+                    let result = if let Ok(solution) = linear_equation::solve(left, right) {
+                        steps.push("Solve linear equation:".to_string());
+                        steps.extend(solution.derivation_steps());
+                        solution.to_value()
+                    } else {
+                        steps.push("Solve polynomial equation:".to_string());
+                        let solution = polynomial_equation::solve(left, right)?;
+                        steps.extend(solution.derivation_steps());
+                        solution.to_value()
+                    };
                     steps.push(format!("Solution: {}", result.to_display_string()));
                     return Ok(result);
                 }

--- a/src/grammar/lexer.rs
+++ b/src/grammar/lexer.rs
@@ -122,6 +122,8 @@ pub enum TokenKind {
     Minus,
     /// The multiplication operator.
     Star,
+    /// The question mark placeholder unknown for equations.
+    Question,
     /// The division operator.
     Slash,
     /// The power/exponent operator.
@@ -255,6 +257,10 @@ impl Lexer {
             '*' => {
                 self.advance();
                 Token::new(TokenKind::Star, start, self.pos, "*".to_string())
+            }
+            '?' => {
+                self.advance();
+                Token::new(TokenKind::Question, start, self.pos, "?".to_string())
             }
             '/' => {
                 self.advance();

--- a/src/grammar/linear_equation.rs
+++ b/src/grammar/linear_equation.rs
@@ -1,0 +1,255 @@
+//! Linear-equation helpers for the expression evaluator.
+
+use crate::error::CalculatorError;
+use crate::types::{BinaryOp, Expression, Rational, Unit, Value};
+
+#[derive(Debug, Clone)]
+struct LinearForm {
+    variable: Option<String>,
+    coefficient: Rational,
+    constant: Rational,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct LinearEquationSolution {
+    variable: String,
+    coefficient: Rational,
+    isolated_constant: Rational,
+    value: Rational,
+    left_form: LinearForm,
+    right_form: LinearForm,
+}
+
+impl LinearForm {
+    fn constant(value: Rational) -> Self {
+        Self {
+            variable: None,
+            coefficient: Rational::zero(),
+            constant: value,
+        }
+    }
+
+    fn variable(name: String) -> Self {
+        Self {
+            variable: Some(name),
+            coefficient: Rational::one(),
+            constant: Rational::zero(),
+        }
+    }
+
+    fn from_expression(expr: &Expression) -> Result<Self, CalculatorError> {
+        match expr {
+            Expression::Number { value, unit, .. } => {
+                if *unit != Unit::None {
+                    return Err(Self::unsupported_equation());
+                }
+                Ok(Self::constant(Rational::from_decimal(*value)))
+            }
+            Expression::Variable(name) => Ok(Self::variable(name.clone())),
+            Expression::Binary { left, op, right } => {
+                let left = Self::from_expression(left)?;
+                let right = Self::from_expression(right)?;
+                match op {
+                    BinaryOp::Add => left.add(right),
+                    BinaryOp::Subtract => left.subtract(right),
+                    BinaryOp::Multiply => left.multiply(right),
+                    BinaryOp::Divide => left.divide(right),
+                    BinaryOp::Modulo => Err(Self::unsupported_equation()),
+                }
+            }
+            Expression::Negate(inner) => Ok(Self::from_expression(inner)?.negate()),
+            Expression::Group(inner) => Self::from_expression(inner),
+            Expression::DateTime(_)
+            | Expression::Now
+            | Expression::Until(_)
+            | Expression::AtTime { .. }
+            | Expression::FunctionCall { .. }
+            | Expression::Power { .. }
+            | Expression::IndefiniteIntegral { .. }
+            | Expression::UnitConversion { .. }
+            | Expression::Equality { .. } => Err(Self::unsupported_equation()),
+        }
+    }
+
+    fn add(self, other: Self) -> Result<Self, CalculatorError> {
+        Ok(Self {
+            variable: Self::merge_variable(self.variable, other.variable)?,
+            coefficient: self.coefficient + other.coefficient,
+            constant: self.constant + other.constant,
+        })
+    }
+
+    fn subtract(self, other: Self) -> Result<Self, CalculatorError> {
+        Ok(Self {
+            variable: Self::merge_variable(self.variable, other.variable)?,
+            coefficient: self.coefficient - other.coefficient,
+            constant: self.constant - other.constant,
+        })
+    }
+
+    fn multiply(self, other: Self) -> Result<Self, CalculatorError> {
+        match (self.variable.is_some(), other.variable.is_some()) {
+            (true, true) => Err(CalculatorError::InvalidOperation(
+                "equation is not linear".into(),
+            )),
+            (true, false) => {
+                let scale = other.constant;
+                Ok(Self {
+                    variable: self.variable,
+                    coefficient: self.coefficient * scale.clone(),
+                    constant: self.constant * scale,
+                })
+            }
+            (false, true) => {
+                let scale = self.constant;
+                Ok(Self {
+                    variable: other.variable,
+                    coefficient: other.coefficient * scale.clone(),
+                    constant: other.constant * scale,
+                })
+            }
+            (false, false) => Ok(Self::constant(self.constant * other.constant)),
+        }
+    }
+
+    fn divide(self, other: Self) -> Result<Self, CalculatorError> {
+        if other.variable.is_some() {
+            return Err(CalculatorError::InvalidOperation(
+                "equation has a variable denominator".into(),
+            ));
+        }
+        if other.constant.is_zero() {
+            return Err(CalculatorError::DivisionByZero);
+        }
+
+        Ok(Self {
+            variable: self.variable,
+            coefficient: self.coefficient / other.constant.clone(),
+            constant: self.constant / other.constant,
+        })
+    }
+
+    fn negate(self) -> Self {
+        Self {
+            variable: self.variable,
+            coefficient: -self.coefficient,
+            constant: -self.constant,
+        }
+    }
+
+    fn merge_variable(
+        left: Option<String>,
+        right: Option<String>,
+    ) -> Result<Option<String>, CalculatorError> {
+        match (left, right) {
+            (Some(left), Some(right)) if left == right => Ok(Some(left)),
+            (Some(_), Some(_)) => Err(CalculatorError::InvalidOperation(
+                "equation has more than one variable".into(),
+            )),
+            (Some(variable), None) | (None, Some(variable)) => Ok(Some(variable)),
+            (None, None) => Ok(None),
+        }
+    }
+
+    fn unsupported_equation() -> CalculatorError {
+        CalculatorError::InvalidOperation(
+            "only simple single-variable linear equations with unitless numbers are supported"
+                .into(),
+        )
+    }
+
+    fn format_with_variable(&self, variable: &str) -> String {
+        let mut result = String::new();
+
+        if !self.coefficient.is_zero() {
+            result.push_str(&Self::format_variable_term(&self.coefficient, variable));
+        }
+
+        if self.constant.is_zero() {
+            if result.is_empty() {
+                return "0".to_string();
+            }
+            return result;
+        }
+
+        if result.is_empty() {
+            return self.constant.to_display_string();
+        }
+
+        if self.constant.is_negative() {
+            result.push_str(" - ");
+            result.push_str(&self.constant.abs().to_display_string());
+        } else {
+            result.push_str(" + ");
+            result.push_str(&self.constant.to_display_string());
+        }
+
+        result
+    }
+
+    fn format_variable_term(coefficient: &Rational, variable: &str) -> String {
+        if coefficient == &Rational::one() {
+            variable.to_string()
+        } else if coefficient == &Rational::from_integer(-1) {
+            format!("-{variable}")
+        } else {
+            format!("{}*{variable}", coefficient.to_display_string())
+        }
+    }
+}
+
+impl LinearEquationSolution {
+    pub(super) fn to_value(&self) -> Value {
+        Value::equation_solution(self.variable.clone(), self.value.clone())
+    }
+
+    pub(super) fn derivation_steps(&self) -> Vec<String> {
+        vec![
+            format!(
+                "Linear form: {} = {}",
+                self.left_form.format_with_variable(&self.variable),
+                self.right_form.format_with_variable(&self.variable)
+            ),
+            format!(
+                "Isolate variable term: {} = {}",
+                LinearForm::format_variable_term(&self.coefficient, &self.variable),
+                self.isolated_constant.to_display_string()
+            ),
+            format!(
+                "Solve for {}: {} = {}",
+                self.variable,
+                self.variable,
+                self.value.to_display_string()
+            ),
+        ]
+    }
+}
+
+pub(super) fn solve(
+    left: &Expression,
+    right: &Expression,
+) -> Result<LinearEquationSolution, CalculatorError> {
+    let left_form = LinearForm::from_expression(left)?;
+    let right_form = LinearForm::from_expression(right)?;
+    let variable =
+        LinearForm::merge_variable(left_form.variable.clone(), right_form.variable.clone())?
+            .ok_or_else(LinearForm::unsupported_equation)?;
+
+    let coefficient = left_form.coefficient.clone() - right_form.coefficient.clone();
+    if coefficient.is_zero() {
+        return Err(CalculatorError::InvalidOperation(
+            "linear equation has no unique solution".into(),
+        ));
+    }
+
+    let isolated_constant = right_form.constant.clone() - left_form.constant.clone();
+    let value = isolated_constant.clone() / coefficient.clone();
+    Ok(LinearEquationSolution {
+        variable,
+        coefficient,
+        isolated_constant,
+        value,
+        left_form,
+        right_form,
+    })
+}

--- a/src/grammar/linear_equation.rs
+++ b/src/grammar/linear_equation.rs
@@ -4,35 +4,50 @@ use crate::error::CalculatorError;
 use crate::types::{BinaryOp, Expression, Rational, Unit, Value};
 
 #[derive(Debug, Clone)]
-struct LinearForm {
-    variable: Option<String>,
+struct LinearTerm {
+    variable: String,
     coefficient: Rational,
+}
+
+#[derive(Debug, Clone)]
+struct LinearForm {
+    terms: Vec<LinearTerm>,
     constant: Rational,
+}
+
+#[derive(Debug, Clone)]
+struct VariableMoveDetail {
+    variable: String,
+    left_coefficient: Rational,
+    right_coefficient: Rational,
+    moved_coefficient: Rational,
 }
 
 #[derive(Debug, Clone)]
 pub(super) struct LinearEquationSolution {
     variable: String,
     coefficient: Rational,
-    isolated_constant: Rational,
-    value: Rational,
+    isolated_expression: LinearForm,
+    value_expression: LinearForm,
     left_form: LinearForm,
     right_form: LinearForm,
+    variable_move_details: Vec<VariableMoveDetail>,
 }
 
 impl LinearForm {
     fn constant(value: Rational) -> Self {
         Self {
-            variable: None,
-            coefficient: Rational::zero(),
+            terms: Vec::new(),
             constant: value,
         }
     }
 
     fn variable(name: String) -> Self {
         Self {
-            variable: Some(name),
-            coefficient: Rational::one(),
+            terms: vec![LinearTerm {
+                variable: name,
+                coefficient: Rational::one(),
+            }],
             constant: Rational::zero(),
         }
     }
@@ -50,10 +65,10 @@ impl LinearForm {
                 let left = Self::from_expression(left)?;
                 let right = Self::from_expression(right)?;
                 match op {
-                    BinaryOp::Add => left.add(right),
-                    BinaryOp::Subtract => left.subtract(right),
+                    BinaryOp::Add => Ok(left.add(right)),
+                    BinaryOp::Subtract => Ok(left.subtract(right)),
                     BinaryOp::Multiply => left.multiply(right),
-                    BinaryOp::Divide => left.divide(right),
+                    BinaryOp::Divide => left.divide(&right),
                     BinaryOp::Modulo => Err(Self::unsupported_equation()),
                 }
             }
@@ -71,157 +86,297 @@ impl LinearForm {
         }
     }
 
-    fn add(self, other: Self) -> Result<Self, CalculatorError> {
-        Ok(Self {
-            variable: Self::merge_variable(self.variable, other.variable)?,
-            coefficient: self.coefficient + other.coefficient,
-            constant: self.constant + other.constant,
-        })
+    fn add(mut self, other: Self) -> Self {
+        for term in other.terms {
+            self.add_term(term.variable, term.coefficient);
+        }
+        self.constant = self.constant + other.constant;
+        self
     }
 
-    fn subtract(self, other: Self) -> Result<Self, CalculatorError> {
-        Ok(Self {
-            variable: Self::merge_variable(self.variable, other.variable)?,
-            coefficient: self.coefficient - other.coefficient,
-            constant: self.constant - other.constant,
-        })
+    fn subtract(mut self, other: Self) -> Self {
+        for term in other.terms {
+            self.add_term(term.variable, -term.coefficient);
+        }
+        self.constant = self.constant - other.constant;
+        self
     }
 
     fn multiply(self, other: Self) -> Result<Self, CalculatorError> {
-        match (self.variable.is_some(), other.variable.is_some()) {
+        match (self.has_variable_terms(), other.has_variable_terms()) {
             (true, true) => Err(CalculatorError::InvalidOperation(
                 "equation is not linear".into(),
             )),
-            (true, false) => {
-                let scale = other.constant;
-                Ok(Self {
-                    variable: self.variable,
-                    coefficient: self.coefficient * scale.clone(),
-                    constant: self.constant * scale,
-                })
-            }
-            (false, true) => {
-                let scale = self.constant;
-                Ok(Self {
-                    variable: other.variable,
-                    coefficient: other.coefficient * scale.clone(),
-                    constant: other.constant * scale,
-                })
-            }
+            (true, false) => Ok(self.scale(&other.constant)),
+            (false, true) => Ok(other.scale(&self.constant)),
             (false, false) => Ok(Self::constant(self.constant * other.constant)),
         }
     }
 
-    fn divide(self, other: Self) -> Result<Self, CalculatorError> {
-        if other.variable.is_some() {
+    fn divide(self, other: &Self) -> Result<Self, CalculatorError> {
+        if other.has_variable_terms() {
             return Err(CalculatorError::InvalidOperation(
                 "equation has a variable denominator".into(),
             ));
         }
-        if other.constant.is_zero() {
-            return Err(CalculatorError::DivisionByZero);
-        }
-
-        Ok(Self {
-            variable: self.variable,
-            coefficient: self.coefficient / other.constant.clone(),
-            constant: self.constant / other.constant,
-        })
+        self.divide_by_rational(&other.constant)
     }
 
     fn negate(self) -> Self {
-        Self {
-            variable: self.variable,
-            coefficient: -self.coefficient,
-            constant: -self.constant,
-        }
+        self.scale(&Rational::from_integer(-1))
     }
 
-    fn merge_variable(
-        left: Option<String>,
-        right: Option<String>,
-    ) -> Result<Option<String>, CalculatorError> {
-        match (left, right) {
-            (Some(left), Some(right)) if left == right => Ok(Some(left)),
-            (Some(_), Some(_)) => Err(CalculatorError::InvalidOperation(
-                "equation has more than one variable".into(),
-            )),
-            (Some(variable), None) | (None, Some(variable)) => Ok(Some(variable)),
-            (None, None) => Ok(None),
+    fn scale(mut self, scale: &Rational) -> Self {
+        self.constant = self.constant * scale.clone();
+        for term in &mut self.terms {
+            term.coefficient = term.coefficient.clone() * scale.clone();
+        }
+        self.remove_zero_terms();
+        self
+    }
+
+    fn divide_by_rational(mut self, denominator: &Rational) -> Result<Self, CalculatorError> {
+        if denominator.is_zero() {
+            return Err(CalculatorError::DivisionByZero);
+        }
+        self.constant = self.constant / denominator.clone();
+        for term in &mut self.terms {
+            term.coefficient = term.coefficient.clone() / denominator.clone();
+        }
+        self.remove_zero_terms();
+        Ok(self)
+    }
+
+    fn add_term(&mut self, variable: String, coefficient: Rational) {
+        if coefficient.is_zero() {
+            return;
+        }
+
+        if let Some(index) = self.terms.iter().position(|term| term.variable == variable) {
+            let new_coefficient = self.terms[index].coefficient.clone() + coefficient;
+            if new_coefficient.is_zero() {
+                self.terms.remove(index);
+            } else {
+                self.terms[index].coefficient = new_coefficient;
+            }
+            return;
+        }
+
+        self.terms.push(LinearTerm {
+            variable,
+            coefficient,
+        });
+    }
+
+    fn remove_zero_terms(&mut self) {
+        self.terms.retain(|term| !term.coefficient.is_zero());
+    }
+
+    fn has_variable_terms(&self) -> bool {
+        !self.terms.is_empty()
+    }
+
+    fn coefficient_of(&self, variable: &str) -> Rational {
+        self.terms
+            .iter()
+            .find(|term| term.variable == variable)
+            .map_or_else(Rational::zero, |term| term.coefficient.clone())
+    }
+
+    fn push_variable_order(&self, variables: &mut Vec<String>) {
+        for term in &self.terms {
+            if !variables.iter().any(|variable| variable == &term.variable) {
+                variables.push(term.variable.clone());
+            }
         }
     }
 
     fn unsupported_equation() -> CalculatorError {
         CalculatorError::InvalidOperation(
-            "only simple single-variable linear equations with unitless numbers are supported"
-                .into(),
+            "only linear equations with unitless numbers are supported".into(),
         )
     }
 
-    fn format_with_variable(&self, variable: &str) -> String {
-        let mut result = String::new();
+    fn format_terms_first(&self) -> String {
+        self.format(false)
+    }
 
-        if !self.coefficient.is_zero() {
-            result.push_str(&Self::format_variable_term(&self.coefficient, variable));
+    fn format_solution_expression(&self) -> String {
+        self.format(true)
+    }
+
+    fn format(&self, constant_first: bool) -> String {
+        let mut parts = Vec::new();
+
+        if constant_first {
+            Self::push_constant_part(&mut parts, &self.constant);
         }
 
-        if self.constant.is_zero() {
-            if result.is_empty() {
-                return "0".to_string();
+        for term in &self.terms {
+            Self::push_variable_part(&mut parts, &term.coefficient, &term.variable);
+        }
+
+        if !constant_first {
+            Self::push_constant_part(&mut parts, &self.constant);
+        }
+
+        Self::join_signed_parts(parts)
+    }
+
+    fn push_constant_part(parts: &mut Vec<(bool, String)>, value: &Rational) {
+        if value.is_zero() {
+            return;
+        }
+        parts.push((value.is_negative(), value.abs().to_display_string()));
+    }
+
+    fn push_variable_part(parts: &mut Vec<(bool, String)>, coefficient: &Rational, variable: &str) {
+        if coefficient.is_zero() {
+            return;
+        }
+        parts.push((
+            coefficient.is_negative(),
+            Self::format_variable_body(&coefficient.abs(), variable),
+        ));
+    }
+
+    fn join_signed_parts(parts: Vec<(bool, String)>) -> String {
+        let mut result = String::new();
+
+        for (index, (is_negative, body)) in parts.into_iter().enumerate() {
+            if index == 0 {
+                if is_negative {
+                    result.push('-');
+                }
+            } else if is_negative {
+                result.push_str(" - ");
+            } else {
+                result.push_str(" + ");
             }
-            return result;
+            result.push_str(&body);
         }
 
         if result.is_empty() {
-            return self.constant.to_display_string();
-        }
-
-        if self.constant.is_negative() {
-            result.push_str(" - ");
-            result.push_str(&self.constant.abs().to_display_string());
+            "0".to_string()
         } else {
-            result.push_str(" + ");
-            result.push_str(&self.constant.to_display_string());
+            result
         }
-
-        result
     }
 
     fn format_variable_term(coefficient: &Rational, variable: &str) -> String {
-        if coefficient == &Rational::one() {
+        if coefficient.is_zero() {
+            return "0".to_string();
+        }
+        Self::join_signed_parts(vec![(
+            coefficient.is_negative(),
+            Self::format_variable_body(&coefficient.abs(), variable),
+        )])
+    }
+
+    fn format_variable_body(coefficient_abs: &Rational, variable: &str) -> String {
+        if coefficient_abs == &Rational::one() {
             variable.to_string()
-        } else if coefficient == &Rational::from_integer(-1) {
-            format!("-{variable}")
+        } else if variable == "*" {
+            format!("{}*(*)", coefficient_abs.to_display_string())
         } else {
-            format!("{}*{variable}", coefficient.to_display_string())
+            format!("{}*{variable}", coefficient_abs.to_display_string())
         }
     }
 }
 
 impl LinearEquationSolution {
     pub(super) fn to_value(&self) -> Value {
-        Value::equation_solution(self.variable.clone(), self.value.clone())
+        if self.value_expression.terms.is_empty() {
+            Value::equation_solution(
+                self.variable.clone(),
+                self.value_expression.constant.clone(),
+            )
+        } else {
+            Value::symbolic_equation_solution(
+                self.variable.clone(),
+                self.value_expression.format_solution_expression(),
+            )
+        }
     }
 
     pub(super) fn derivation_steps(&self) -> Vec<String> {
-        vec![
+        let mut steps = vec![
+            format!(
+                "Original equation: {} = {}",
+                self.left_form.format_terms_first(),
+                self.right_form.format_terms_first()
+            ),
             format!(
                 "Linear form: {} = {}",
-                self.left_form.format_with_variable(&self.variable),
-                self.right_form.format_with_variable(&self.variable)
+                self.left_form.format_terms_first(),
+                self.right_form.format_terms_first()
+            ),
+            format!("Choose target variable: {}", self.variable),
+            format!(
+                "Combine target coefficients: {} - {} = {}",
+                self.left_form
+                    .coefficient_of(&self.variable)
+                    .to_display_string(),
+                self.right_form
+                    .coefficient_of(&self.variable)
+                    .to_display_string(),
+                self.coefficient.to_display_string()
+            ),
+            format!(
+                "Move non-target variable terms to the right: {}",
+                self.format_variable_move_details()
+            ),
+            format!(
+                "Move constants to the right: {} - {} = {}",
+                self.right_form.constant.to_display_string(),
+                self.left_form.constant.to_display_string(),
+                self.isolated_expression.constant.to_display_string()
+            ),
+            format!(
+                "Right side after moving terms: {}",
+                self.isolated_expression.format_solution_expression()
             ),
             format!(
                 "Isolate variable term: {} = {}",
                 LinearForm::format_variable_term(&self.coefficient, &self.variable),
-                self.isolated_constant.to_display_string()
+                self.isolated_expression.format_solution_expression()
             ),
             format!(
-                "Solve for {}: {} = {}",
+                "Divide both sides by {}: {} = {}",
+                self.coefficient.to_display_string(),
                 self.variable,
-                self.variable,
-                self.value.to_display_string()
+                self.value_expression.format_solution_expression()
             ),
-        ]
+        ];
+
+        steps.push(format!(
+            "Solve for {}: {} = {}",
+            self.variable,
+            self.variable,
+            self.value_expression.format_solution_expression()
+        ));
+
+        steps
+    }
+
+    fn format_variable_move_details(&self) -> String {
+        if self.variable_move_details.is_empty() {
+            return "no other variables to move".to_string();
+        }
+
+        self.variable_move_details
+            .iter()
+            .map(|detail| {
+                format!(
+                    "{}: {} - {} = {}",
+                    detail.variable,
+                    detail.right_coefficient.to_display_string(),
+                    detail.left_coefficient.to_display_string(),
+                    detail.moved_coefficient.to_display_string()
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("; ")
     }
 }
 
@@ -231,25 +386,107 @@ pub(super) fn solve(
 ) -> Result<LinearEquationSolution, CalculatorError> {
     let left_form = LinearForm::from_expression(left)?;
     let right_form = LinearForm::from_expression(right)?;
+    let variables = collect_variable_order(&left_form, &right_form);
     let variable =
-        LinearForm::merge_variable(left_form.variable.clone(), right_form.variable.clone())?
-            .ok_or_else(LinearForm::unsupported_equation)?;
+        select_target_variable(&left_form, &right_form, &variables).ok_or_else(|| {
+            CalculatorError::InvalidOperation("linear equation has no unique solution".into())
+        })?;
 
-    let coefficient = left_form.coefficient.clone() - right_form.coefficient.clone();
+    let coefficient = left_form.coefficient_of(&variable) - right_form.coefficient_of(&variable);
     if coefficient.is_zero() {
         return Err(CalculatorError::InvalidOperation(
             "linear equation has no unique solution".into(),
         ));
     }
 
-    let isolated_constant = right_form.constant.clone() - left_form.constant.clone();
-    let value = isolated_constant.clone() / coefficient.clone();
+    let isolated_expression = isolate_right_side(&left_form, &right_form, &variables, &variable);
+    let value_expression = isolated_expression
+        .clone()
+        .divide_by_rational(&coefficient)?;
+    let variable_move_details =
+        build_variable_move_details(&left_form, &right_form, &variables, &variable);
+
     Ok(LinearEquationSolution {
         variable,
         coefficient,
-        isolated_constant,
-        value,
+        isolated_expression,
+        value_expression,
         left_form,
         right_form,
+        variable_move_details,
     })
+}
+
+fn collect_variable_order(left: &LinearForm, right: &LinearForm) -> Vec<String> {
+    let mut variables = Vec::new();
+    left.push_variable_order(&mut variables);
+    right.push_variable_order(&mut variables);
+    variables
+}
+
+fn select_target_variable(
+    left: &LinearForm,
+    right: &LinearForm,
+    variables: &[String],
+) -> Option<String> {
+    for preferred in ["?", "*"] {
+        if variables.iter().any(|variable| variable == preferred)
+            && !combined_target_coefficient(left, right, preferred).is_zero()
+        {
+            return Some(preferred.to_string());
+        }
+    }
+
+    variables
+        .iter()
+        .find(|variable| !combined_target_coefficient(left, right, variable).is_zero())
+        .cloned()
+}
+
+fn combined_target_coefficient(left: &LinearForm, right: &LinearForm, variable: &str) -> Rational {
+    left.coefficient_of(variable) - right.coefficient_of(variable)
+}
+
+fn isolate_right_side(
+    left: &LinearForm,
+    right: &LinearForm,
+    variables: &[String],
+    target_variable: &str,
+) -> LinearForm {
+    let mut isolated = LinearForm::constant(right.constant.clone() - left.constant.clone());
+
+    for variable in variables {
+        if variable == target_variable {
+            continue;
+        }
+
+        let coefficient = right.coefficient_of(variable) - left.coefficient_of(variable);
+        isolated.add_term(variable.clone(), coefficient);
+    }
+
+    isolated
+}
+
+fn build_variable_move_details(
+    left: &LinearForm,
+    right: &LinearForm,
+    variables: &[String],
+    target_variable: &str,
+) -> Vec<VariableMoveDetail> {
+    variables
+        .iter()
+        .filter(|variable| variable.as_str() != target_variable)
+        .map(|variable| {
+            let left_coefficient = left.coefficient_of(variable);
+            let right_coefficient = right.coefficient_of(variable);
+            let moved_coefficient = right_coefficient.clone() - left_coefficient.clone();
+
+            VariableMoveDetail {
+                variable: variable.clone(),
+                left_coefficient,
+                right_coefficient,
+                moved_coefficient,
+            }
+        })
+        .collect()
 }

--- a/src/grammar/mod.rs
+++ b/src/grammar/mod.rs
@@ -7,6 +7,7 @@ mod lexer;
 mod linear_equation;
 mod math_functions;
 mod number_grammar;
+mod polynomial_equation;
 mod token_parser;
 
 pub use datetime_grammar::DateTimeGrammar;

--- a/src/grammar/mod.rs
+++ b/src/grammar/mod.rs
@@ -4,6 +4,7 @@ mod datetime_grammar;
 mod expression_parser;
 mod integral;
 mod lexer;
+mod linear_equation;
 mod math_functions;
 mod number_grammar;
 mod token_parser;

--- a/src/grammar/polynomial_equation.rs
+++ b/src/grammar/polynomial_equation.rs
@@ -1,0 +1,667 @@
+//! Polynomial-equation helpers for the expression evaluator.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::error::CalculatorError;
+use crate::types::{BinaryOp, Expression, Rational, Unit, Value};
+
+const MAX_POLYNOMIAL_DEGREE: u32 = 32;
+const ROOT_SEARCH_BOUND: i128 = 100;
+const MAX_FACTORABLE_COEFFICIENT_ABS: i128 = 1_000_000_000;
+
+#[derive(Debug, Clone)]
+struct PolynomialForm {
+    variable: Option<String>,
+    terms: BTreeMap<u32, Rational>,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct PolynomialEquationSolution {
+    variable: String,
+    polynomial: PolynomialForm,
+    degree: u32,
+    roots: Vec<Rational>,
+    original_left: String,
+    original_right: String,
+}
+
+impl PolynomialForm {
+    fn constant(value: Rational) -> Self {
+        let mut terms = BTreeMap::new();
+        if !value.is_zero() {
+            terms.insert(0, value);
+        }
+        Self {
+            variable: None,
+            terms,
+        }
+    }
+
+    fn variable(name: String) -> Self {
+        let mut terms = BTreeMap::new();
+        terms.insert(1, Rational::one());
+        Self {
+            variable: Some(name),
+            terms,
+        }
+    }
+
+    fn from_expression(expr: &Expression) -> Result<Self, CalculatorError> {
+        match expr {
+            Expression::Number { value, unit, .. } => {
+                if *unit != Unit::None {
+                    return Err(Self::unsupported_equation());
+                }
+                Ok(Self::constant(Rational::from_decimal(*value)))
+            }
+            Expression::Variable(name) => Ok(Self::variable(name.clone())),
+            Expression::Binary { left, op, right } => {
+                let left = Self::from_expression(left)?;
+                let right = Self::from_expression(right)?;
+                match op {
+                    BinaryOp::Add => left.add(right),
+                    BinaryOp::Subtract => left.subtract(right),
+                    BinaryOp::Multiply => left.multiply(right),
+                    BinaryOp::Divide => left.divide(&right),
+                    BinaryOp::Modulo => Err(Self::unsupported_equation()),
+                }
+            }
+            Expression::Negate(inner) => Ok(Self::from_expression(inner)?.negate()),
+            Expression::Group(inner) => Self::from_expression(inner),
+            Expression::Power { base, exponent } => {
+                let base = Self::from_expression(base)?;
+                let exponent =
+                    Self::from_expression(exponent)?.as_non_negative_integer_exponent()?;
+                base.pow(exponent)
+            }
+            Expression::DateTime(_)
+            | Expression::Now
+            | Expression::Until(_)
+            | Expression::AtTime { .. }
+            | Expression::FunctionCall { .. }
+            | Expression::IndefiniteIntegral { .. }
+            | Expression::UnitConversion { .. }
+            | Expression::Equality { .. } => Err(Self::unsupported_equation()),
+        }
+    }
+
+    fn add(self, other: Self) -> Result<Self, CalculatorError> {
+        let variable = merge_variable_names(self.variable, other.variable)?;
+        let mut result = Self {
+            variable,
+            terms: self.terms,
+        };
+
+        for (degree, coefficient) in other.terms {
+            result.add_term(degree, coefficient);
+        }
+
+        Ok(result)
+    }
+
+    fn subtract(self, other: Self) -> Result<Self, CalculatorError> {
+        self.add(other.negate())
+    }
+
+    fn multiply(self, other: Self) -> Result<Self, CalculatorError> {
+        let variable = merge_variable_names(self.variable, other.variable)?;
+        let mut result = Self {
+            variable,
+            terms: BTreeMap::new(),
+        };
+
+        for (left_degree, left_coefficient) in self.terms {
+            for (right_degree, right_coefficient) in &other.terms {
+                let degree = left_degree
+                    .checked_add(*right_degree)
+                    .filter(|degree| *degree <= MAX_POLYNOMIAL_DEGREE)
+                    .ok_or_else(Self::unsupported_equation)?;
+                result.add_term(degree, left_coefficient.clone() * right_coefficient.clone());
+            }
+        }
+
+        Ok(result)
+    }
+
+    fn divide(self, other: &Self) -> Result<Self, CalculatorError> {
+        if other.has_variable_terms() {
+            return Err(CalculatorError::InvalidOperation(
+                "polynomial equation has a variable denominator".into(),
+            ));
+        }
+
+        let denominator = other.coefficient(0);
+        if denominator.is_zero() {
+            return Err(CalculatorError::DivisionByZero);
+        }
+
+        self.divide_by_rational(&denominator)
+    }
+
+    fn pow(self, exponent: u32) -> Result<Self, CalculatorError> {
+        if exponent == 0 {
+            return Ok(Self::constant(Rational::one()));
+        }
+
+        let mut result = Self::constant(Rational::one());
+        for _ in 0..exponent {
+            result = result.multiply(self.clone())?;
+        }
+
+        Ok(result)
+    }
+
+    fn negate(self) -> Self {
+        self.scale(&Rational::from_integer(-1))
+    }
+
+    fn scale(mut self, scale: &Rational) -> Self {
+        for coefficient in self.terms.values_mut() {
+            *coefficient = coefficient.clone() * scale.clone();
+        }
+        self.remove_zero_terms();
+        self
+    }
+
+    fn divide_by_rational(mut self, denominator: &Rational) -> Result<Self, CalculatorError> {
+        if denominator.is_zero() {
+            return Err(CalculatorError::DivisionByZero);
+        }
+
+        for coefficient in self.terms.values_mut() {
+            *coefficient = coefficient.clone() / denominator.clone();
+        }
+        self.remove_zero_terms();
+        Ok(self)
+    }
+
+    fn add_term(&mut self, degree: u32, coefficient: Rational) {
+        if coefficient.is_zero() {
+            return;
+        }
+
+        let new_coefficient = self.coefficient(degree) + coefficient;
+        if new_coefficient.is_zero() {
+            self.terms.remove(&degree);
+        } else {
+            self.terms.insert(degree, new_coefficient);
+        }
+    }
+
+    fn remove_zero_terms(&mut self) {
+        self.terms.retain(|_, coefficient| !coefficient.is_zero());
+        if !self.has_variable_terms() {
+            self.variable = None;
+        }
+    }
+
+    fn has_variable_terms(&self) -> bool {
+        self.terms.keys().any(|degree| *degree > 0)
+    }
+
+    fn coefficient(&self, degree: u32) -> Rational {
+        self.terms
+            .get(&degree)
+            .map_or_else(Rational::zero, Clone::clone)
+    }
+
+    fn degree(&self) -> u32 {
+        self.terms.keys().next_back().copied().unwrap_or(0)
+    }
+
+    fn as_non_negative_integer_exponent(&self) -> Result<u32, CalculatorError> {
+        if self.has_variable_terms() {
+            return Err(Self::unsupported_equation());
+        }
+
+        let exponent = self.coefficient(0);
+        if !exponent.is_integer() {
+            return Err(Self::unsupported_equation());
+        }
+
+        let exponent = exponent.numer();
+        if exponent < 0 || exponent > i128::from(MAX_POLYNOMIAL_DEGREE) {
+            return Err(Self::unsupported_equation());
+        }
+
+        u32::try_from(exponent).map_err(|_| Self::unsupported_equation())
+    }
+
+    fn evaluate_at(&self, value: &Rational) -> Rational {
+        let mut result = Rational::zero();
+
+        for degree in (0..=self.degree()).rev() {
+            result = result * value.clone() + self.coefficient(degree);
+        }
+
+        result
+    }
+
+    fn format(&self) -> String {
+        let Some(variable) = &self.variable else {
+            return self.coefficient(0).to_display_string();
+        };
+
+        let parts = self
+            .terms
+            .iter()
+            .rev()
+            .map(|(degree, coefficient)| {
+                let coefficient_abs = coefficient.abs();
+                (
+                    coefficient.is_negative(),
+                    Self::format_term_body(&coefficient_abs, *degree, variable),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        join_signed_parts(parts)
+    }
+
+    fn format_term_body(coefficient_abs: &Rational, degree: u32, variable: &str) -> String {
+        if degree == 0 {
+            return coefficient_abs.to_display_string();
+        }
+
+        let variable_power = format_variable_power(variable, degree);
+        if coefficient_abs == &Rational::one() {
+            variable_power
+        } else {
+            format!("{}*{variable_power}", coefficient_abs.to_display_string())
+        }
+    }
+
+    fn unsupported_equation() -> CalculatorError {
+        CalculatorError::InvalidOperation(
+            "only polynomial equations with one variable, unitless numbers, nonnegative integer powers, and real rational roots are supported".into(),
+        )
+    }
+}
+
+impl PolynomialEquationSolution {
+    pub(super) fn to_value(&self) -> Value {
+        if self.roots.len() == 1 {
+            Value::equation_solution(self.variable.clone(), self.roots[0].clone())
+        } else {
+            Value::equation_solutions(self.variable.clone(), self.roots.clone())
+        }
+    }
+
+    pub(super) fn derivation_steps(&self) -> Vec<String> {
+        let mut steps = vec![
+            format!(
+                "Original equation: {} = {}",
+                self.original_left, self.original_right
+            ),
+            format!("Move all terms to the left: {} = 0", self.polynomial.format()),
+            format!("Polynomial form: {} = 0", self.polynomial.format()),
+            format!("Polynomial degree: {}", self.degree),
+            format!("Choose target variable: {}", self.variable),
+            "Find real rational roots: test exact rational candidates and keep the values that make the polynomial equal 0".to_string(),
+        ];
+
+        for root in &self.roots {
+            steps.push(format!(
+                "Verify root {}: substituting {} = {} gives 0",
+                root.to_display_string(),
+                self.variable,
+                root.to_display_string()
+            ));
+        }
+
+        steps.push(format!(
+            "Factor roots: {}",
+            format_root_factors(&self.variable, &self.roots)
+        ));
+        steps.push(format!(
+            "Solutions: {}",
+            format_solutions(&self.variable, &self.roots)
+        ));
+
+        steps
+    }
+}
+
+pub(super) fn solve(
+    left: &Expression,
+    right: &Expression,
+) -> Result<PolynomialEquationSolution, CalculatorError> {
+    let left_form = PolynomialForm::from_expression(left)?;
+    let right_form = PolynomialForm::from_expression(right)?;
+    let polynomial = left_form.subtract(right_form)?;
+    let variable = polynomial.variable.clone().ok_or_else(|| {
+        CalculatorError::InvalidOperation("polynomial equation has no variable".into())
+    })?;
+    let degree = polynomial.degree();
+
+    if degree <= 1 {
+        return Err(CalculatorError::InvalidOperation(
+            "polynomial equation is linear".into(),
+        ));
+    }
+
+    let roots = find_real_rational_roots(&polynomial);
+    if roots.is_empty() {
+        return Err(CalculatorError::InvalidOperation(
+            "polynomial equation has no supported real rational solutions".into(),
+        ));
+    }
+
+    Ok(PolynomialEquationSolution {
+        variable,
+        polynomial,
+        degree,
+        roots,
+        original_left: left.to_string(),
+        original_right: right.to_string(),
+    })
+}
+
+fn merge_variable_names(
+    left: Option<String>,
+    right: Option<String>,
+) -> Result<Option<String>, CalculatorError> {
+    match (left, right) {
+        (Some(left), Some(right)) if left != right => Err(CalculatorError::InvalidOperation(
+            "polynomial equations with multiple variables are not supported".into(),
+        )),
+        (Some(variable), _) | (_, Some(variable)) => Ok(Some(variable)),
+        (None, None) => Ok(None),
+    }
+}
+
+fn find_real_rational_roots(polynomial: &PolynomialForm) -> Vec<Rational> {
+    if let Some(roots) = binomial_power_roots(polynomial) {
+        return roots;
+    }
+
+    let mut roots = BTreeSet::new();
+
+    if polynomial.degree() == 2 {
+        roots.extend(quadratic_roots(polynomial));
+    }
+
+    for candidate in rational_root_candidates(polynomial) {
+        if polynomial.evaluate_at(&candidate).is_zero() {
+            roots.insert(candidate);
+        }
+    }
+
+    roots.into_iter().collect()
+}
+
+fn binomial_power_roots(polynomial: &PolynomialForm) -> Option<Vec<Rational>> {
+    let degree = polynomial.degree();
+    if degree < 2 {
+        return None;
+    }
+
+    let has_only_high_and_constant_terms = polynomial
+        .terms
+        .keys()
+        .all(|term_degree| *term_degree == 0 || *term_degree == degree);
+    if !has_only_high_and_constant_terms {
+        return None;
+    }
+
+    let leading = polynomial.coefficient(degree);
+    if leading.is_zero() {
+        return None;
+    }
+
+    let target = -polynomial.coefficient(0) / leading;
+    if target.is_zero() {
+        return Some(vec![Rational::zero()]);
+    }
+
+    if target.is_negative() && degree % 2 == 0 {
+        return Some(Vec::new());
+    }
+
+    let root = rational_nth_root(&target, degree)?;
+    if degree % 2 == 0 {
+        let negative_root = -root.clone();
+        Some(vec![negative_root, root])
+    } else {
+        Some(vec![root])
+    }
+}
+
+fn quadratic_roots(polynomial: &PolynomialForm) -> Vec<Rational> {
+    let a = polynomial.coefficient(2);
+    let b = polynomial.coefficient(1);
+    let c = polynomial.coefficient(0);
+    if a.is_zero() {
+        return Vec::new();
+    }
+
+    let four = Rational::from_integer(4);
+    let two = Rational::from_integer(2);
+    let discriminant = b.clone() * b.clone() - four * a.clone() * c;
+    let Some(square_root) = rational_square_root(&discriminant) else {
+        return Vec::new();
+    };
+
+    let denominator = two * a;
+    let first = (-b.clone() - square_root.clone()) / denominator.clone();
+    let second = (-b + square_root) / denominator;
+
+    match first.cmp(&second) {
+        std::cmp::Ordering::Equal => vec![first],
+        std::cmp::Ordering::Less => vec![first, second],
+        std::cmp::Ordering::Greater => vec![second, first],
+    }
+}
+
+fn rational_square_root(value: &Rational) -> Option<Rational> {
+    rational_nth_root(value, 2)
+}
+
+fn rational_nth_root(value: &Rational, degree: u32) -> Option<Rational> {
+    if value.is_negative() {
+        if degree % 2 == 0 {
+            return None;
+        }
+
+        return rational_nth_root(&value.abs(), degree).map(std::ops::Neg::neg);
+    }
+
+    let numerator = u128::try_from(value.numer()).ok()?;
+    let denominator = u128::try_from(value.denom()).ok()?;
+    let numerator_root = integer_nth_root(numerator, degree)?;
+    let denominator_root = integer_nth_root(denominator, degree)?;
+
+    Some(Rational::new(
+        i128::try_from(numerator_root).ok()?,
+        i128::try_from(denominator_root).ok()?,
+    ))
+}
+
+fn integer_nth_root(value: u128, degree: u32) -> Option<u128> {
+    let mut low = 0;
+    let mut high = value;
+
+    while low <= high {
+        let midpoint = low + (high - low) / 2;
+        match checked_pow_u128(midpoint, degree) {
+            Some(power) if power == value => return Some(midpoint),
+            Some(power) if power < value => low = midpoint + 1,
+            _ => {
+                if midpoint == 0 {
+                    break;
+                }
+                high = midpoint - 1;
+            }
+        }
+    }
+
+    None
+}
+
+fn checked_pow_u128(base: u128, exponent: u32) -> Option<u128> {
+    let mut result = 1_u128;
+
+    for _ in 0..exponent {
+        result = result.checked_mul(base)?;
+    }
+
+    Some(result)
+}
+
+fn rational_root_candidates(polynomial: &PolynomialForm) -> BTreeSet<Rational> {
+    let mut candidates = (-ROOT_SEARCH_BOUND..=ROOT_SEARCH_BOUND)
+        .map(Rational::from_integer)
+        .collect::<BTreeSet<_>>();
+
+    if let Some(exact_candidates) = rational_root_theorem_candidates(polynomial) {
+        candidates.extend(exact_candidates);
+    }
+
+    candidates
+}
+
+fn rational_root_theorem_candidates(polynomial: &PolynomialForm) -> Option<BTreeSet<Rational>> {
+    let lowest_degree = *polynomial.terms.keys().next()?;
+    let highest_degree = polynomial.degree();
+    let mut denominator_lcm = 1_i128;
+
+    for coefficient in polynomial.terms.values() {
+        denominator_lcm = checked_lcm(denominator_lcm, coefficient.denom())?;
+    }
+
+    let constant = scaled_integer_coefficient(polynomial, lowest_degree, denominator_lcm)?;
+    let leading = scaled_integer_coefficient(polynomial, highest_degree, denominator_lcm)?;
+    let numerator_factors = positive_divisors(constant)?;
+    let denominator_factors = positive_divisors(leading)?;
+    let mut candidates = BTreeSet::new();
+
+    for numerator in numerator_factors {
+        for denominator in &denominator_factors {
+            candidates.insert(Rational::new(numerator, *denominator));
+            candidates.insert(Rational::new(-numerator, *denominator));
+        }
+    }
+
+    if lowest_degree > 0 {
+        candidates.insert(Rational::zero());
+    }
+
+    Some(candidates)
+}
+
+fn scaled_integer_coefficient(
+    polynomial: &PolynomialForm,
+    degree: u32,
+    denominator_lcm: i128,
+) -> Option<i128> {
+    let coefficient = polynomial.coefficient(degree);
+    coefficient
+        .numer()
+        .checked_mul(denominator_lcm.checked_div(coefficient.denom())?)
+}
+
+fn checked_lcm(left: i128, right: i128) -> Option<i128> {
+    let gcd = gcd_i128(left, right);
+    left.checked_div(gcd)?.checked_mul(right)?.checked_abs()
+}
+
+fn gcd_i128(mut left: i128, mut right: i128) -> i128 {
+    left = left.abs();
+    right = right.abs();
+
+    while right != 0 {
+        let remainder = left % right;
+        left = right;
+        right = remainder;
+    }
+
+    left
+}
+
+fn positive_divisors(value: i128) -> Option<Vec<i128>> {
+    let value = value.checked_abs()?;
+    if value == 0 || value > MAX_FACTORABLE_COEFFICIENT_ABS {
+        return None;
+    }
+
+    let mut divisors = Vec::new();
+    let mut candidate = 1_i128;
+    while candidate <= value / candidate {
+        if value % candidate == 0 {
+            divisors.push(candidate);
+            let paired = value / candidate;
+            if paired != candidate {
+                divisors.push(paired);
+            }
+        }
+        candidate += 1;
+    }
+
+    Some(divisors)
+}
+
+fn format_solutions(variable: &str, roots: &[Rational]) -> String {
+    roots
+        .iter()
+        .map(|root| format!("{variable} = {}", root.to_display_string()))
+        .collect::<Vec<_>>()
+        .join(" or ")
+}
+
+fn format_root_factors(variable: &str, roots: &[Rational]) -> String {
+    roots
+        .iter()
+        .map(|root| format_root_factor(variable, root))
+        .collect::<Vec<_>>()
+        .join(" * ")
+}
+
+fn format_root_factor(variable: &str, root: &Rational) -> String {
+    let variable = format_variable_power(variable, 1);
+    if root.is_zero() {
+        return variable;
+    }
+
+    if root.is_negative() {
+        format!("({variable} + {})", root.abs().to_display_string())
+    } else {
+        format!("({variable} - {})", root.to_display_string())
+    }
+}
+
+fn format_variable_power(variable: &str, degree: u32) -> String {
+    let variable = if variable == "*" {
+        "(*)".to_string()
+    } else {
+        variable.to_string()
+    };
+
+    if degree == 1 {
+        variable
+    } else {
+        format!("{variable}^{degree}")
+    }
+}
+
+fn join_signed_parts(parts: Vec<(bool, String)>) -> String {
+    let mut result = String::new();
+
+    for (index, (is_negative, body)) in parts.into_iter().enumerate() {
+        if index == 0 {
+            if is_negative {
+                result.push('-');
+            }
+        } else if is_negative {
+            result.push_str(" - ");
+        } else {
+            result.push_str(" + ");
+        }
+        result.push_str(&body);
+    }
+
+    if result.is_empty() {
+        "0".to_string()
+    } else {
+        result
+    }
+}

--- a/src/grammar/token_parser.rs
+++ b/src/grammar/token_parser.rs
@@ -188,6 +188,16 @@ impl<'a> TokenParser<'a> {
             return Ok(Expression::group(expr));
         }
 
+        // Placeholder unknowns for single-variable equations.
+        if self.check(&TokenKind::Question) {
+            self.advance();
+            return Ok(Expression::variable("?"));
+        }
+        if self.check(&TokenKind::Star) {
+            self.advance();
+            return Ok(Expression::variable("*"));
+        }
+
         // Numeric date literal (e.g. 2026-01-22, 15/10/2025, 15.10.2025).
         // The lexer already validated that this parses as a real calendar date.
         if let Some(TokenKind::DateLiteral(s)) = self.current_kind() {

--- a/src/types/value/duration.rs
+++ b/src/types/value/duration.rs
@@ -1,0 +1,44 @@
+/// Formats a duration in seconds to a human-readable string.
+pub(super) fn format_duration(total_seconds: i64) -> String {
+    let is_negative = total_seconds < 0;
+    let total_seconds = total_seconds.abs();
+
+    let days = total_seconds / 86400;
+    let hours = (total_seconds % 86400) / 3600;
+    let minutes = (total_seconds % 3600) / 60;
+    let seconds = total_seconds % 60;
+
+    let mut parts = Vec::new();
+
+    if days > 0 {
+        parts.push(format!("{} day{}", days, if days == 1 { "" } else { "s" }));
+    }
+    if hours > 0 {
+        parts.push(format!(
+            "{} hour{}",
+            hours,
+            if hours == 1 { "" } else { "s" }
+        ));
+    }
+    if minutes > 0 {
+        parts.push(format!(
+            "{} minute{}",
+            minutes,
+            if minutes == 1 { "" } else { "s" }
+        ));
+    }
+    if seconds > 0 || parts.is_empty() {
+        parts.push(format!(
+            "{} second{}",
+            seconds,
+            if seconds == 1 { "" } else { "s" }
+        ));
+    }
+
+    let result = parts.join(", ");
+    if is_negative {
+        format!("-{result}")
+    } else {
+        result
+    }
+}

--- a/src/types/value/kind.rs
+++ b/src/types/value/kind.rs
@@ -1,0 +1,35 @@
+use serde::{Deserialize, Serialize};
+
+use crate::types::{DateTime, Decimal, Rational};
+
+/// Different kinds of values the calculator can work with.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ValueKind {
+    /// A decimal number (for compatibility and complex operations).
+    Number(Decimal),
+    /// A rational number for exact fractional arithmetic.
+    Rational(Rational),
+    /// A date and/or time.
+    DateTime(DateTime),
+    /// A duration (difference between two datetimes).
+    Duration {
+        /// Duration in seconds.
+        seconds: i64,
+    },
+    /// A boolean value.
+    Boolean(bool),
+    /// A solved single-variable equation.
+    EquationSolution {
+        /// The solved variable name.
+        variable: String,
+        /// The value assigned to the variable.
+        value: Rational,
+    },
+    /// A solved linear equation whose result still contains other variables.
+    SymbolicEquationSolution {
+        /// The solved variable name.
+        variable: String,
+        /// The symbolic expression assigned to the variable.
+        expression: String,
+    },
+}

--- a/src/types/value/kind.rs
+++ b/src/types/value/kind.rs
@@ -25,6 +25,13 @@ pub enum ValueKind {
         /// The value assigned to the variable.
         value: Rational,
     },
+    /// A solved equation with multiple exact values for the same variable.
+    EquationSolutions {
+        /// The solved variable name.
+        variable: String,
+        /// The values assigned to the variable.
+        values: Vec<Rational>,
+    },
     /// A solved linear equation whose result still contains other variables.
     SymbolicEquationSolution {
         /// The solved variable name.

--- a/src/types/value/mod.rs
+++ b/src/types/value/mod.rs
@@ -1,5 +1,8 @@
 //! Value type representing typed values with units.
 
+mod kind;
+pub use kind::ValueKind;
+
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -13,31 +16,6 @@ pub struct Value {
     pub kind: ValueKind,
     /// The unit of measurement.
     pub unit: Unit,
-}
-
-/// Different kinds of values the calculator can work with.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum ValueKind {
-    /// A decimal number (for compatibility and complex operations).
-    Number(Decimal),
-    /// A rational number for exact fractional arithmetic.
-    Rational(Rational),
-    /// A date and/or time.
-    DateTime(DateTime),
-    /// A duration (difference between two datetimes).
-    Duration {
-        /// Duration in seconds.
-        seconds: i64,
-    },
-    /// A boolean value.
-    Boolean(bool),
-    /// A solved single-variable equation.
-    EquationSolution {
-        /// The solved variable name.
-        variable: String,
-        /// The value assigned to the variable.
-        value: Rational,
-    },
 }
 
 impl Value {
@@ -138,6 +116,21 @@ impl Value {
             kind: ValueKind::EquationSolution {
                 variable: variable.into(),
                 value,
+            },
+            unit: Unit::None,
+        }
+    }
+
+    /// Creates a solved symbolic equation value.
+    #[must_use]
+    pub fn symbolic_equation_solution(
+        variable: impl Into<String>,
+        expression: impl Into<String>,
+    ) -> Self {
+        Self {
+            kind: ValueKind::SymbolicEquationSolution {
+                variable: variable.into(),
+                expression: expression.into(),
             },
             unit: Unit::None,
         }
@@ -823,7 +816,9 @@ impl Value {
             ValueKind::DateTime(_) => "datetime",
             ValueKind::Duration { .. } => "duration",
             ValueKind::Boolean(_) => "boolean",
-            ValueKind::EquationSolution { .. } => "equation solution",
+            ValueKind::EquationSolution { .. } | ValueKind::SymbolicEquationSolution { .. } => {
+                "equation solution"
+            }
         }
     }
 
@@ -852,6 +847,12 @@ impl Value {
             ValueKind::Boolean(b) => b.to_string(),
             ValueKind::EquationSolution { variable, value } => {
                 format!("{variable} = {}", value.to_display_string())
+            }
+            ValueKind::SymbolicEquationSolution {
+                variable,
+                expression,
+            } => {
+                format!("{variable} = {expression}")
             }
         }
     }

--- a/src/types/value/mod.rs
+++ b/src/types/value/mod.rs
@@ -1,6 +1,8 @@
 //! Value type representing typed values with units.
 
+mod duration;
 mod kind;
+use duration::format_duration;
 pub use kind::ValueKind;
 
 use serde::{Deserialize, Serialize};
@@ -116,6 +118,18 @@ impl Value {
             kind: ValueKind::EquationSolution {
                 variable: variable.into(),
                 value,
+            },
+            unit: Unit::None,
+        }
+    }
+
+    /// Creates a solved equation value with multiple exact solutions.
+    #[must_use]
+    pub fn equation_solutions(variable: impl Into<String>, values: Vec<Rational>) -> Self {
+        Self {
+            kind: ValueKind::EquationSolutions {
+                variable: variable.into(),
+                values,
             },
             unit: Unit::None,
         }
@@ -816,9 +830,9 @@ impl Value {
             ValueKind::DateTime(_) => "datetime",
             ValueKind::Duration { .. } => "duration",
             ValueKind::Boolean(_) => "boolean",
-            ValueKind::EquationSolution { .. } | ValueKind::SymbolicEquationSolution { .. } => {
-                "equation solution"
-            }
+            ValueKind::EquationSolution { .. }
+            | ValueKind::EquationSolutions { .. }
+            | ValueKind::SymbolicEquationSolution { .. } => "equation solution",
         }
     }
 
@@ -848,6 +862,11 @@ impl Value {
             ValueKind::EquationSolution { variable, value } => {
                 format!("{variable} = {}", value.to_display_string())
             }
+            ValueKind::EquationSolutions { variable, values } => values
+                .iter()
+                .map(|value| format!("{variable} = {}", value.to_display_string()))
+                .collect::<Vec<_>>()
+                .join(" or "),
             ValueKind::SymbolicEquationSolution {
                 variable,
                 expression,
@@ -947,51 +966,6 @@ fn add_calendar_months_or_duration(dt: &DateTime, unit: DurationUnit, amount: f6
                 dt.add_duration(-seconds)
             }
         }
-    }
-}
-
-/// Formats a duration in seconds to a human-readable string.
-fn format_duration(total_seconds: i64) -> String {
-    let is_negative = total_seconds < 0;
-    let total_seconds = total_seconds.abs();
-
-    let days = total_seconds / 86400;
-    let hours = (total_seconds % 86400) / 3600;
-    let minutes = (total_seconds % 3600) / 60;
-    let seconds = total_seconds % 60;
-
-    let mut parts = Vec::new();
-
-    if days > 0 {
-        parts.push(format!("{} day{}", days, if days == 1 { "" } else { "s" }));
-    }
-    if hours > 0 {
-        parts.push(format!(
-            "{} hour{}",
-            hours,
-            if hours == 1 { "" } else { "s" }
-        ));
-    }
-    if minutes > 0 {
-        parts.push(format!(
-            "{} minute{}",
-            minutes,
-            if minutes == 1 { "" } else { "s" }
-        ));
-    }
-    if seconds > 0 || parts.is_empty() {
-        parts.push(format!(
-            "{} second{}",
-            seconds,
-            if seconds == 1 { "" } else { "s" }
-        ));
-    }
-
-    let result = parts.join(", ");
-    if is_negative {
-        format!("-{result}")
-    } else {
-        result
     }
 }
 

--- a/tests/issue_174_placeholder_equation_tests.rs
+++ b/tests/issue_174_placeholder_equation_tests.rs
@@ -118,6 +118,34 @@ fn solves_symbolic_multi_variable_equations() {
 }
 
 #[test]
+fn solves_quadratic_and_higher_power_equations() {
+    assert_equation_solutions(&[
+        ("x^2 = 4", "x = -2 or x = 2"),
+        ("x^2 - 5 * x + 6 = 0", "x = 2 or x = 3"),
+        ("x^2 + 5 * x + 6 = 0", "x = -3 or x = -2"),
+        ("x^2 = 0", "x = 0"),
+        ("x^3 = 27", "x = 3"),
+        ("x^3 - x = 0", "x = -1 or x = 0 or x = 1"),
+        ("x^4 = 16", "x = -2 or x = 2"),
+        ("x^5 - 32 = 0", "x = 2"),
+        ("x^6 - 64 = 0", "x = -2 or x = 2"),
+        ("x^7 + 128 = 0", "x = -2"),
+        ("(x - 2) * (x + 3) = 0", "x = -3 or x = 2"),
+        ("(x - 1)^3 = 0", "x = 1"),
+        ("(x - 1) * (x - 2) * (x - 3) = 0", "x = 1 or x = 2 or x = 3"),
+        (
+            "(2 * x - 1) * (x - 3) * (x + 2) = 0",
+            "x = -2 or x = 0.5 or x = 3",
+        ),
+        ("2 * x^2 - 8 = 0", "x = -2 or x = 2"),
+        ("?^2 = 9", "? = -3 or ? = 3"),
+        ("*^2 = 9", "* = -3 or * = 3"),
+        ("? * ? = 4", "? = -2 or ? = 2"),
+        ("* * * = 4", "* = -2 or * = 2"),
+    ]);
+}
+
+#[test]
 fn solves_more_than_500_named_multi_variable_equations_with_explicit_steps() {
     let variables = ["x", "y", "z", "a", "b", "c", "m", "n", "p", "q", "r", "s"];
     let mut case_count = 0;
@@ -141,6 +169,30 @@ fn solves_more_than_500_named_multi_variable_equations_with_explicit_steps() {
     assert!(
         case_count > 500,
         "expected more than 500 generated multi-variable cases, got {case_count}"
+    );
+}
+
+#[test]
+fn solves_more_than_1000_power_equation_edge_cases_with_explicit_steps() {
+    let variables = ["x", "y", "z", "a", "b", "c", "m", "n", "p", "q"];
+    let mut case_count = 0;
+
+    for variable in variables {
+        for power in 2..=11 {
+            for root in -5..=5 {
+                let rhs = pow_i128(root, power);
+                let input = format!("{variable}^{power} = {rhs}");
+                let expected = expected_power_solution(variable, root, power);
+
+                assert_polynomial_solution_with_required_steps(&input, &expected);
+                case_count += 1;
+            }
+        }
+    }
+
+    assert!(
+        case_count > 1000,
+        "expected more than 1000 generated power-equation cases, got {case_count}"
     );
 }
 
@@ -194,8 +246,41 @@ fn calculate_with_value_returns_structured_symbolic_solution_and_detailed_trace(
 }
 
 #[test]
+fn calculate_with_value_returns_structured_polynomial_solutions_and_detailed_trace() {
+    let mut calc = Calculator::new();
+    let (_expr, value, steps, lino) = calc
+        .calculate_with_value("x^2 - 5 * x + 6 = 0")
+        .expect("quadratic equation should solve");
+
+    assert_eq!(value.to_display_string(), "x = 2 or x = 3");
+    assert_eq!(
+        value.kind,
+        ValueKind::EquationSolutions {
+            variable: "x".to_string(),
+            values: vec![Rational::from_integer(2), Rational::from_integer(3)],
+        }
+    );
+    assert_eq!(lino, "((((x ^ 2) - (5 * x)) + 6) = 0)");
+    assert_required_polynomial_step_labels(&steps, "x^2 - 5 * x + 6 = 0");
+}
+
+#[test]
 fn rejects_unsupported_placeholder_equations() {
-    for input in ["? * ? = 4", "* * * = 4", "? + = 4", "2 * = 8", "** + 2 = 4"] {
+    for input in ["? + = 4", "2 * = 8", "** + 2 = 4"] {
+        let mut calc = Calculator::new();
+        let result = calc.calculate_internal(input);
+
+        assert!(
+            !result.success,
+            "expected {input:?} to be rejected, got {}",
+            result.result
+        );
+    }
+}
+
+#[test]
+fn rejects_unsupported_polynomial_equations() {
+    for input in ["x^2 + y = 4", "x / x = 1", "x^2 = 2"] {
         let mut calc = Calculator::new();
         let result = calc.calculate_internal(input);
 
@@ -248,6 +333,24 @@ fn assert_equation_solution_with_required_steps(input: &str, expected: &str) {
     assert_required_step_labels(&steps, input);
 }
 
+fn assert_polynomial_solution_with_required_steps(input: &str, expected: &str) {
+    let mut calc = Calculator::new();
+    let (_expr, value, steps, lino) = calc
+        .calculate_with_value(input)
+        .unwrap_or_else(|err| panic!("expected success for {input:?}, got {err:?}"));
+
+    assert_eq!(
+        value.to_display_string(),
+        expected,
+        "wrong result for {input:?}"
+    );
+    assert!(
+        lino.contains('='),
+        "equation lino should contain '=' for {input:?}: {lino}",
+    );
+    assert_required_polynomial_step_labels(&steps, input);
+}
+
 fn assert_required_step_labels(steps: &[String], input: &str) {
     for label in [
         "Input expression:",
@@ -270,4 +373,47 @@ fn assert_required_step_labels(steps: &[String], input: &str) {
             "steps for {input:?} should include {label:?}: {steps:?}"
         );
     }
+}
+
+fn assert_required_polynomial_step_labels(steps: &[String], input: &str) {
+    for label in [
+        "Input expression:",
+        "Solve polynomial equation:",
+        "Original equation:",
+        "Move all terms to the left:",
+        "Polynomial form:",
+        "Polynomial degree:",
+        "Choose target variable:",
+        "Find real rational roots:",
+        "Verify root",
+        "Solutions:",
+        "Solution:",
+        "Final result:",
+    ] {
+        assert!(
+            steps.iter().any(|step| step.starts_with(label)),
+            "steps for {input:?} should include {label:?}: {steps:?}"
+        );
+    }
+}
+
+fn expected_power_solution(variable: &str, root: i128, power: u32) -> String {
+    if root == 0 {
+        return format!("{variable} = 0");
+    }
+
+    if power % 2 == 0 {
+        let root_abs = root.abs();
+        format!("{variable} = -{root_abs} or {variable} = {root_abs}")
+    } else {
+        format!("{variable} = {root}")
+    }
+}
+
+fn pow_i128(value: i128, power: u32) -> i128 {
+    let mut result = 1;
+    for _ in 0..power {
+        result *= value;
+    }
+    result
 }

--- a/tests/issue_174_placeholder_equation_tests.rs
+++ b/tests/issue_174_placeholder_equation_tests.rs
@@ -106,6 +106,45 @@ fn named_variable_equations_keep_working_across_many_shapes() {
 }
 
 #[test]
+fn solves_symbolic_multi_variable_equations() {
+    assert_equation_solutions(&[
+        ("x + y = 10", "x = 10 - y"),
+        ("2 * x + 3 * y = 12", "x = 6 - 1.5*y"),
+        ("y + x = 10", "y = 10 - x"),
+        ("x + ? = 4", "? = 4 - x"),
+        ("x + * = 4", "* = 4 - x"),
+        ("? + * = 4", "? = 4 - *"),
+    ]);
+}
+
+#[test]
+fn solves_more_than_500_named_multi_variable_equations_with_explicit_steps() {
+    let variables = ["x", "y", "z", "a", "b", "c", "m", "n", "p", "q", "r", "s"];
+    let mut case_count = 0;
+
+    for target in variables {
+        for other in variables {
+            if target == other {
+                continue;
+            }
+
+            for total in 2..=6 {
+                let input = format!("{target} + {other} = {total}");
+                let expected = format!("{target} = {total} - {other}");
+
+                assert_equation_solution_with_required_steps(&input, &expected);
+                case_count += 1;
+            }
+        }
+    }
+
+    assert!(
+        case_count > 500,
+        "expected more than 500 generated multi-variable cases, got {case_count}"
+    );
+}
+
+#[test]
 fn calculate_with_value_returns_structured_placeholder_solution_and_trace() {
     let mut calc = Calculator::new();
     let (_expr, value, steps, lino) = calc
@@ -136,17 +175,27 @@ fn calculate_with_value_returns_structured_placeholder_solution_and_trace() {
 }
 
 #[test]
-fn rejects_mixed_unknowns_and_unsupported_placeholder_equations() {
-    for input in [
-        "x + ? = 4",
-        "? + * = 4",
-        "x + * = 4",
-        "? * ? = 4",
-        "* * * = 4",
-        "? + = 4",
-        "2 * = 8",
-        "** + 2 = 4",
-    ] {
+fn calculate_with_value_returns_structured_symbolic_solution_and_detailed_trace() {
+    let mut calc = Calculator::new();
+    let (_expr, value, steps, lino) = calc
+        .calculate_with_value("2 * x + 3 * y = 12")
+        .expect("multi-variable equation should solve symbolically");
+
+    assert_eq!(value.to_display_string(), "x = 6 - 1.5*y");
+    assert_eq!(
+        value.kind,
+        ValueKind::SymbolicEquationSolution {
+            variable: "x".to_string(),
+            expression: "6 - 1.5*y".to_string(),
+        }
+    );
+    assert_eq!(lino, "(((2 * x) + (3 * y)) = 12)");
+    assert_required_step_labels(&steps, "2 * x + 3 * y = 12");
+}
+
+#[test]
+fn rejects_unsupported_placeholder_equations() {
+    for input in ["? * ? = 4", "* * * = 4", "? + = 4", "2 * = 8", "** + 2 = 4"] {
         let mut calc = Calculator::new();
         let result = calc.calculate_internal(input);
 
@@ -179,4 +228,46 @@ fn assert_equation_solution(input: &str, expected: &str) {
         "equation lino should contain '=' for {input:?}: {}",
         result.lino_interpretation
     );
+}
+
+fn assert_equation_solution_with_required_steps(input: &str, expected: &str) {
+    let mut calc = Calculator::new();
+    let (_expr, value, steps, lino) = calc
+        .calculate_with_value(input)
+        .unwrap_or_else(|err| panic!("expected success for {input:?}, got {err:?}"));
+
+    assert_eq!(
+        value.to_display_string(),
+        expected,
+        "wrong result for {input:?}"
+    );
+    assert!(
+        lino.contains('='),
+        "equation lino should contain '=' for {input:?}: {lino}",
+    );
+    assert_required_step_labels(&steps, input);
+}
+
+fn assert_required_step_labels(steps: &[String], input: &str) {
+    for label in [
+        "Input expression:",
+        "Solve linear equation:",
+        "Original equation:",
+        "Linear form:",
+        "Choose target variable:",
+        "Combine target coefficients:",
+        "Move non-target variable terms to the right:",
+        "Move constants to the right:",
+        "Right side after moving terms:",
+        "Isolate variable term:",
+        "Divide both sides by",
+        "Solve for",
+        "Solution:",
+        "Final result:",
+    ] {
+        assert!(
+            steps.iter().any(|step| step.starts_with(label)),
+            "steps for {input:?} should include {label:?}: {steps:?}"
+        );
+    }
 }

--- a/tests/issue_174_placeholder_equation_tests.rs
+++ b/tests/issue_174_placeholder_equation_tests.rs
@@ -1,0 +1,182 @@
+//! Regression tests for issue #174: placeholder unknowns in linear equations.
+
+use link_calculator::{
+    types::{Rational, ValueKind},
+    Calculator,
+};
+
+#[test]
+fn solves_question_mark_placeholder_equations() {
+    assert_equation_solutions(&[
+        ("? + 2 = 4", "? = 2"),
+        ("2 + ? = 4", "? = 2"),
+        ("4 = ? + 2", "? = 2"),
+        ("? - 2 = 4", "? = 6"),
+        ("10 - ? = 4", "? = 6"),
+        ("? * 2 = 8", "? = 4"),
+        ("2 * ? = 8", "? = 4"),
+        ("? / 2 = 4", "? = 8"),
+        ("(? + 2) * 3 = 12", "? = 2"),
+        ("3 * (? + 2) = 12", "? = 2"),
+        ("? + ? = 10", "? = 5"),
+        ("2 * ? + 3 = 11", "? = 4"),
+        ("3 + 2 * ? = 11", "? = 4"),
+        ("10 = ? / 3 + 1", "? = 27"),
+        ("? / 3 + 1 = 10", "? = 27"),
+        ("? + 2.5 = 4", "? = 1.5"),
+        ("? - 0.5 = 2", "? = 2.5"),
+        ("2 * (? - 1) = 6", "? = 4"),
+        ("(? - 1) / 3 = 2", "? = 7"),
+        ("-? + 10 = 4", "? = 6"),
+        ("? + (-2) = 4", "? = 6"),
+        ("2 * ? - 4 = 0", "? = 2"),
+        ("0 = 2 * ? - 4", "? = 2"),
+        ("? + 0 = 7", "? = 7"),
+        ("1 * ? = 9", "? = 9"),
+    ]);
+}
+
+#[test]
+fn solves_star_placeholder_equations_by_parser_position() {
+    assert_equation_solutions(&[
+        ("* + 2 = 4", "* = 2"),
+        ("2 + * = 4", "* = 2"),
+        ("4 = * + 2", "* = 2"),
+        ("* - 2 = 4", "* = 6"),
+        ("10 - * = 4", "* = 6"),
+        ("* * 2 = 8", "* = 4"),
+        ("2 * * = 8", "* = 4"),
+        ("* / 2 = 4", "* = 8"),
+        ("(* + 2) * 3 = 12", "* = 2"),
+        ("3 * (* + 2) = 12", "* = 2"),
+        ("* + * = 10", "* = 5"),
+        ("2 * * + 3 = 11", "* = 4"),
+        ("3 + 2 * * = 11", "* = 4"),
+        ("10 = * / 3 + 1", "* = 27"),
+        ("* / 3 + 1 = 10", "* = 27"),
+        ("* + 2.5 = 4", "* = 1.5"),
+        ("* - 0.5 = 2", "* = 2.5"),
+        ("2 * (* - 1) = 6", "* = 4"),
+        ("(* - 1) / 3 = 2", "* = 7"),
+        ("-* + 10 = 4", "* = 6"),
+        ("* + (-2) = 4", "* = 6"),
+        ("2 * * - 4 = 0", "* = 2"),
+        ("0 = 2 * * - 4", "* = 2"),
+        ("* + 0 = 7", "* = 7"),
+        ("1 * * = 9", "* = 9"),
+    ]);
+}
+
+#[test]
+fn named_variable_equations_keep_working_across_many_shapes() {
+    for variable in ["x", "y", "z"] {
+        for (template, expected_value) in [
+            ("{v} + 2 = 4", "2"),
+            ("2 + {v} = 4", "2"),
+            ("4 = {v} + 2", "2"),
+            ("{v} - 2 = 4", "6"),
+            ("10 - {v} = 4", "6"),
+            ("{v} * 2 = 8", "4"),
+            ("2 * {v} = 8", "4"),
+            ("{v} / 2 = 4", "8"),
+            ("({v} + 2) * 3 = 12", "2"),
+            ("3 * ({v} + 2) = 12", "2"),
+            ("{v} + {v} = 10", "5"),
+            ("2 * {v} + 3 = 11", "4"),
+            ("3 + 2 * {v} = 11", "4"),
+            ("10 = {v} / 3 + 1", "27"),
+            ("{v} / 3 + 1 = 10", "27"),
+            ("{v} + 2.5 = 4", "1.5"),
+            ("{v} - 0.5 = 2", "2.5"),
+            ("2 * ({v} - 1) = 6", "4"),
+            ("({v} - 1) / 3 = 2", "7"),
+            ("-{v} + 10 = 4", "6"),
+            ("{v} + (-2) = 4", "6"),
+            ("2 * {v} - 4 = 0", "2"),
+            ("0 = 2 * {v} - 4", "2"),
+            ("{v} + 0 = 7", "7"),
+            ("1 * {v} = 9", "9"),
+        ] {
+            let input = template.replace("{v}", variable);
+            let expected = format!("{variable} = {expected_value}");
+
+            assert_equation_solution(&input, &expected);
+        }
+    }
+}
+
+#[test]
+fn calculate_with_value_returns_structured_placeholder_solution_and_trace() {
+    let mut calc = Calculator::new();
+    let (_expr, value, steps, lino) = calc
+        .calculate_with_value("2 * ? + 3 = 11")
+        .expect("placeholder equation should solve");
+
+    assert_eq!(value.to_display_string(), "? = 4");
+    assert_eq!(
+        value.kind,
+        ValueKind::EquationSolution {
+            variable: "?".to_string(),
+            value: Rational::from_integer(4),
+        }
+    );
+    assert_eq!(lino, "(((2 * ?) + 3) = 11)");
+    assert!(
+        steps.iter().any(|step| step == "Solve linear equation:"),
+        "steps should mark equation solving: {steps:?}"
+    );
+    assert!(
+        steps.iter().any(|step| step.starts_with("Linear form:")),
+        "steps should expose the normalized linear form: {steps:?}"
+    );
+    assert!(
+        steps.iter().any(|step| step.starts_with("Solve for ?:")),
+        "steps should expose the derivation step for the placeholder: {steps:?}"
+    );
+}
+
+#[test]
+fn rejects_mixed_unknowns_and_unsupported_placeholder_equations() {
+    for input in [
+        "x + ? = 4",
+        "? + * = 4",
+        "x + * = 4",
+        "? * ? = 4",
+        "* * * = 4",
+        "? + = 4",
+        "2 * = 8",
+        "** + 2 = 4",
+    ] {
+        let mut calc = Calculator::new();
+        let result = calc.calculate_internal(input);
+
+        assert!(
+            !result.success,
+            "expected {input:?} to be rejected, got {}",
+            result.result
+        );
+    }
+}
+
+fn assert_equation_solutions(cases: &[(&str, &str)]) {
+    for (input, expected) in cases {
+        assert_equation_solution(input, expected);
+    }
+}
+
+fn assert_equation_solution(input: &str, expected: &str) {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal(input);
+
+    assert!(
+        result.success,
+        "expected success for {input:?}, got {:?}",
+        result.error
+    );
+    assert_eq!(result.result, expected, "wrong result for {input:?}");
+    assert!(
+        result.lino_interpretation.contains('='),
+        "equation lino should contain '=' for {input:?}: {}",
+        result.lino_interpretation
+    );
+}


### PR DESCRIPTION
## Summary
- Support placeholder unknowns (`?` and operand-position `*`) in equation solving, including repeated placeholders such as `? * ? = 4` and `* * * = 4`.
- Support symbolic solutions for multi-variable linear equations, such as `x + y = 10` -> `x = 10 - y`.
- Add exact real rational root solving for supported single-variable polynomial equations with nonnegative integer powers, including quadratic and higher-power cases such as `x^2 = 4`, `x^3 - x = 0`, and factored cubic equations.
- Add structured multi-root equation values (`EquationSolutions`) and detailed polynomial derivation steps.
- Move the duration display helper into a child module to keep `src/types/value/mod.rs` under the file-size limit.

## Reproduction
Before this PR, placeholder equations and polynomial equations were rejected by the linear-only path. Examples that now solve:

```text
? + 3 = 7        -> ? = 4
2 * x + 3*y = 12 -> x = 6 - 1.5*y
x^2 = 4         -> x = -2 or x = 2
x^3 - x = 0     -> x = -1 or x = 0 or x = 1
? * ? = 4       -> ? = -2 or ? = 2
* * * = 4       -> * = -2 or * = 2
```

## Tests
- `cargo fmt --check`
- `node scripts/check-file-size.mjs`
- `node scripts/check-changelog-fragment.mjs`
- `cargo test --test issue_174_placeholder_equation_tests`
- `cargo test --test issue_160_linear_equation_tests`
- `cargo test --test expression_parser_tests`
- `cargo test`
- `cargo clippy --all-targets --all-features`

## Coverage
- Adds focused quadratic and higher-power equation cases.
- Adds a generated matrix of 1100 power-equation edge cases across 10 variable names, powers 2 through 11, and roots -5 through 5, with explicit derivation-step assertions.
- Keeps the generated multi-variable linear equation coverage from the previous PR scope.
- Adds unsupported-case coverage for multi-variable polynomial equations, variable denominators, and irrational polynomial roots.

Fixes #174
