### PR TITLE
Cover star placeholder equation traces

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-12T12:09:30.090Z for PR creation at branch issue-174-9a192a393486 for issue https://github.com/link-assistant/calculator/issues/174

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-12T12:09:30.090Z for PR creation at branch issue-174-9a192a393486 for issue https://github.com/link-assistant/calculator/issues/174

--- a/changelog.d/20260612_122000_issue_174_star_placeholder_trace.md
+++ b/changelog.d/20260612_122000_issue_174_star_placeholder_trace.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- Added regression coverage for structured `*` placeholder equation results and derivation traces.

--- a/tests/issue_174_placeholder_equation_tests.rs
+++ b/tests/issue_174_placeholder_equation_tests.rs
@@ -302,6 +302,59 @@ fn calculate_with_value_returns_structured_placeholder_solution_and_trace() {
 }
 
 #[test]
+fn calculate_with_value_returns_structured_star_placeholder_solution_and_trace() {
+    let mut calc = Calculator::new();
+    let (_expr, value, steps, lino) = calc
+        .calculate_with_value("2 * * + 3 = 11")
+        .expect("star placeholder equation should solve");
+
+    assert_eq!(value.to_display_string(), "* = 4");
+    assert_eq!(
+        value.kind,
+        ValueKind::EquationSolution {
+            variable: "*".to_string(),
+            value: Rational::from_integer(4),
+        }
+    );
+    assert_eq!(lino, "(((2 * *) + 3) = 11)");
+    assert!(
+        steps.iter().any(|step| step == "Solve linear equation:"),
+        "steps should mark equation solving: {steps:?}"
+    );
+    assert!(
+        steps.iter().any(|step| step.starts_with("Linear form:")),
+        "steps should expose the normalized linear form: {steps:?}"
+    );
+    assert!(
+        steps.iter().any(|step| step.starts_with("Solve for *:")),
+        "steps should expose the derivation step for the star placeholder: {steps:?}"
+    );
+}
+
+#[test]
+fn calculate_with_value_returns_structured_repeated_placeholder_solution() {
+    for (input, variable, expected_value) in [
+        ("? + ? = 10", "?", Rational::from_integer(5)),
+        ("* + * = 10", "*", Rational::from_integer(5)),
+    ] {
+        let mut calc = Calculator::new();
+        let (_expr, value, steps, _lino) = calc
+            .calculate_with_value(input)
+            .unwrap_or_else(|err| panic!("expected success for {input:?}, got {err:?}"));
+
+        assert_eq!(
+            value.kind,
+            ValueKind::EquationSolution {
+                variable: variable.to_string(),
+                value: expected_value,
+            },
+            "wrong structured solution for {input:?}"
+        );
+        assert_required_step_labels(&steps, input);
+    }
+}
+
+#[test]
 fn calculate_with_value_returns_structured_symbolic_solution_and_detailed_trace() {
     let mut calc = Calculator::new();
     let (_expr, value, steps, lino) = calc


### PR DESCRIPTION
## Summary
- Add structured `calculate_with_value` coverage for `2 * * + 3 = 11`, including `ValueKind::EquationSolution`, display output, LINO, and derivation trace assertions.
- Add repeated placeholder structured checks for `? + ? = 10` and `* + * = 10`.
- Add a patch changelog fragment for the issue #174 coverage follow-up.

## Reproduction
Issue #174 requires placeholder unknowns to return structured equation solutions and reasoning steps. The implementation from PR #175 and expanded coverage from PR #176 are already on `main`; this follow-up covers the remaining structured `*` placeholder trace path directly in calculator tests.

## Tests
- `cargo fmt --check`
- `node scripts/check-file-size.mjs`
- `node scripts/check-changelog-fragment.mjs`
- `cargo test --test issue_174_placeholder_equation_tests`
- `cargo test --test issue_160_linear_equation_tests`
- `cargo test`
- `cargo clippy --all-targets --all-features`

Fixes #174