### PR TITLE
Support comparison expressions

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-12T22:42:28.685Z for PR creation at branch issue-183-dfe4e14ea042 for issue https://github.com/link-assistant/calculator/issues/183

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-12T22:42:28.685Z for PR creation at branch issue-183-dfe4e14ea042 for issue https://github.com/link-assistant/calculator/issues/183

--- a/changelog.d/20260612_225115_comparison_syntax.md
+++ b/changelog.d/20260612_225115_comparison_syntax.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+---
+
+### Added
+- Added comparison syntax for `<`, `>`, `<=`, `>=`, `!=`, `==`, `compare A and B`, and `A vs B`.

--- a/src/grammar/expression_parser.rs
+++ b/src/grammar/expression_parser.rs
@@ -8,8 +8,10 @@ use crate::grammar::{
     evaluate_function, evaluate_indefinite_integral, DateTimeGrammar, Lexer, NumberGrammar,
 };
 use crate::types::{
-    BinaryOp, CurrencyDatabase, DateTime, Decimal, Expression, Rational, Value, ValueKind,
+    BinaryOp, ComparisonOp, CurrencyDatabase, DateTime, Decimal, Expression, Rational, Unit, Value,
+    ValueKind,
 };
+use std::cmp::Ordering;
 
 /// Evaluates a power expression, using exact rational arithmetic when possible.
 ///
@@ -147,8 +149,11 @@ impl ExpressionParser {
             | Expression::Power {
                 base: left,
                 exponent: right,
+            } => {
+                Self::expression_contains_variable(left)
+                    || Self::expression_contains_variable(right)
             }
-            | Expression::Equality { left, right } => {
+            Expression::Equality { left, right } | Expression::Comparison { left, right, .. } => {
                 Self::expression_contains_variable(left)
                     || Self::expression_contains_variable(right)
             }
@@ -319,6 +324,11 @@ impl ExpressionParser {
                 let left_val = self.evaluate_expr(left)?;
                 let right_val = self.evaluate_expr(right)?;
                 Ok(Value::boolean(left_val == right_val))
+            }
+            Expression::Comparison { left, op, right } => {
+                let left_val = self.evaluate_expr(left)?;
+                let right_val = self.evaluate_expr(right)?;
+                self.evaluate_comparison_values(&left_val, *op, &right_val)
             }
         }
     }
@@ -577,6 +587,167 @@ impl ExpressionParser {
                 steps.push(format!("= {}", result.to_display_string()));
                 Ok(result)
             }
+            Expression::Comparison { left, op, right } => {
+                let left_val = self.evaluate_expr_with_steps(left, steps)?;
+                let right_val = self.evaluate_expr_with_steps(right, steps)?;
+                let operator = if *op == ComparisonOp::Compare {
+                    "vs"
+                } else {
+                    op.symbol()
+                };
+                steps.push(format!(
+                    "Compare: {} {} {}",
+                    left_val.to_display_string(),
+                    operator,
+                    right_val.to_display_string()
+                ));
+                self.currency_db.clear_last_used_rate();
+                let result = self.evaluate_comparison_values(&left_val, *op, &right_val)?;
+                for (from, to, rate_info) in self.currency_db.get_last_used_rates() {
+                    steps.push(format!(
+                        "Exchange rate: {}",
+                        rate_info.format_for_display(from, to)
+                    ));
+                }
+                steps.push(format!("= {}", result.to_display_string()));
+                Ok(result)
+            }
+        }
+    }
+
+    fn evaluate_comparison_values(
+        &mut self,
+        left: &Value,
+        op: ComparisonOp,
+        right: &Value,
+    ) -> Result<Value, CalculatorError> {
+        if op == ComparisonOp::Equal {
+            return Ok(Value::boolean(
+                self.compare_values(left, right)
+                    .map_or_else(|_| left == right, |ordering| ordering == Ordering::Equal),
+            ));
+        }
+
+        if op == ComparisonOp::NotEqual {
+            return Ok(Value::boolean(
+                self.compare_values(left, right)
+                    .map_or_else(|_| left != right, |ordering| ordering != Ordering::Equal),
+            ));
+        }
+
+        let ordering = self.compare_values(left, right)?;
+        let result = match op {
+            ComparisonOp::Less => Value::boolean(ordering == Ordering::Less),
+            ComparisonOp::LessOrEqual => {
+                Value::boolean(matches!(ordering, Ordering::Less | Ordering::Equal))
+            }
+            ComparisonOp::Greater => Value::boolean(ordering == Ordering::Greater),
+            ComparisonOp::GreaterOrEqual => {
+                Value::boolean(matches!(ordering, Ordering::Greater | Ordering::Equal))
+            }
+            ComparisonOp::Compare => Value::comparison_result(
+                left.to_display_string(),
+                Self::ordering_symbol(ordering),
+                right.to_display_string(),
+            ),
+            ComparisonOp::Equal => unreachable!("handled before ordering comparison"),
+            ComparisonOp::NotEqual => unreachable!("handled before ordering comparison"),
+        };
+
+        Ok(result)
+    }
+
+    fn compare_values(&mut self, left: &Value, right: &Value) -> Result<Ordering, CalculatorError> {
+        if let (Some(left_seconds), Some(right_seconds)) = (
+            Self::duration_seconds_for_comparison(left),
+            Self::duration_seconds_for_comparison(right),
+        ) {
+            return left_seconds.partial_cmp(&right_seconds).ok_or_else(|| {
+                CalculatorError::InvalidOperation(format!(
+                    "cannot order {} and {}",
+                    left.type_name(),
+                    right.type_name()
+                ))
+            });
+        }
+
+        let (left, right) = self.normalize_comparison_values(left, right)?;
+
+        if let (Some(left_rational), Some(right_rational)) =
+            (left.to_rational(), right.to_rational())
+        {
+            return Ok(left_rational.cmp(&right_rational));
+        }
+
+        match (&left.kind, &right.kind) {
+            (ValueKind::DateTime(left_dt), ValueKind::DateTime(right_dt)) => {
+                Ok(left_dt.cmp(right_dt))
+            }
+            (
+                ValueKind::Duration {
+                    seconds: left_seconds,
+                },
+                ValueKind::Duration {
+                    seconds: right_seconds,
+                },
+            ) => Ok(left_seconds.cmp(right_seconds)),
+            _ => Err(CalculatorError::InvalidOperation(format!(
+                "cannot order {} and {}",
+                left.type_name(),
+                right.type_name()
+            ))),
+        }
+    }
+
+    fn normalize_comparison_values(
+        &mut self,
+        left: &Value,
+        right: &Value,
+    ) -> Result<(Value, Value), CalculatorError> {
+        if left.unit == right.unit {
+            return Ok((left.clone(), right.clone()));
+        }
+
+        if left.unit == Unit::None || right.unit == Unit::None {
+            return Err(CalculatorError::InvalidOperation(format!(
+                "cannot compare {} with {}",
+                left.to_display_string(),
+                right.to_display_string()
+            )));
+        }
+
+        let date_context = self.current_date_context.clone();
+        let right_converted = right
+            .convert_to_unit_at_date(&left.unit, &mut self.currency_db, date_context.as_ref())
+            .map_err(|_| {
+                CalculatorError::InvalidOperation(format!(
+                    "cannot compare {} with {}",
+                    left.to_display_string(),
+                    right.to_display_string()
+                ))
+            })?;
+
+        Ok((left.clone(), right_converted))
+    }
+
+    fn duration_seconds_for_comparison(value: &Value) -> Option<f64> {
+        match (&value.kind, &value.unit) {
+            (ValueKind::Duration { seconds }, Unit::None) => Some(*seconds as f64),
+            (ValueKind::Number(decimal), Unit::Duration(unit)) => {
+                Some(unit.to_secs(decimal.to_f64()))
+            }
+            (ValueKind::Rational(rational), Unit::Duration(unit)) => {
+                Some(unit.to_secs(rational.to_f64()))
+            }
+            _ => None,
+        }
+    }
+
+    const fn ordering_symbol(ordering: Ordering) -> &'static str {
+        match ordering {
+            Ordering::Less => "<",
+            Ordering::Equal => "=",
+            Ordering::Greater => ">",
         }
     }
 
@@ -803,6 +974,11 @@ impl ExpressionParser {
                 let left_val = self.evaluate_expr_with_var(left, var_name, var_value)?;
                 let right_val = self.evaluate_expr_with_var(right, var_name, var_value)?;
                 Ok(Value::boolean(left_val == right_val))
+            }
+            Expression::Comparison { left, op, right } => {
+                let left_val = self.evaluate_expr_with_var(left, var_name, var_value)?;
+                let right_val = self.evaluate_expr_with_var(right, var_name, var_value)?;
+                self.evaluate_comparison_values(&left_val, *op, &right_val)
             }
         }
     }

--- a/src/grammar/lexer.rs
+++ b/src/grammar/lexer.rs
@@ -150,8 +150,26 @@ pub enum TokenKind {
     Until,
     /// The "of" keyword for percent-of expressions (e.g., `8% of $50`).
     Of,
+    /// The "and" keyword for natural comparison forms.
+    And,
+    /// The "compare" keyword for natural comparison forms.
+    Compare,
+    /// The "vs" / "versus" keyword for natural comparison forms.
+    Vs,
     /// The equals sign for equality checks (e.g., `1 + 1 = 2`).
     Equals,
+    /// The explicit equality comparison operator (`==`).
+    DoubleEquals,
+    /// The not-equals comparison operator (`!=`).
+    NotEqual,
+    /// The less-than comparison operator (`<`).
+    Less,
+    /// The less-than-or-equal comparison operator (`<=`).
+    LessOrEqual,
+    /// The greater-than comparison operator (`>`).
+    Greater,
+    /// The greater-than-or-equal comparison operator (`>=`).
+    GreaterOrEqual,
     /// The exclamation mark for factorial postfix notation (e.g., `5!`).
     Bang,
     /// End of input.
@@ -292,11 +310,39 @@ impl Lexer {
             }
             '=' => {
                 self.advance();
-                Token::new(TokenKind::Equals, start, self.pos, "=".to_string())
+                if !self.is_at_end() && self.current() == '=' {
+                    self.advance();
+                    Token::new(TokenKind::DoubleEquals, start, self.pos, "==".to_string())
+                } else {
+                    Token::new(TokenKind::Equals, start, self.pos, "=".to_string())
+                }
             }
             '!' => {
                 self.advance();
-                Token::new(TokenKind::Bang, start, self.pos, "!".to_string())
+                if !self.is_at_end() && self.current() == '=' {
+                    self.advance();
+                    Token::new(TokenKind::NotEqual, start, self.pos, "!=".to_string())
+                } else {
+                    Token::new(TokenKind::Bang, start, self.pos, "!".to_string())
+                }
+            }
+            '<' => {
+                self.advance();
+                if !self.is_at_end() && self.current() == '=' {
+                    self.advance();
+                    Token::new(TokenKind::LessOrEqual, start, self.pos, "<=".to_string())
+                } else {
+                    Token::new(TokenKind::Less, start, self.pos, "<".to_string())
+                }
+            }
+            '>' => {
+                self.advance();
+                if !self.is_at_end() && self.current() == '=' {
+                    self.advance();
+                    Token::new(TokenKind::GreaterOrEqual, start, self.pos, ">=".to_string())
+                } else {
+                    Token::new(TokenKind::Greater, start, self.pos, ">".to_string())
+                }
             }
             _ if ch.is_ascii_digit() => {
                 // Prefer a full numeric date literal (e.g. 2026-01-22, 15.10.2025)
@@ -475,6 +521,9 @@ impl Lexer {
             "to" => TokenKind::To,
             "until" => TokenKind::Until,
             "of" => TokenKind::Of,
+            "and" => TokenKind::And,
+            "compare" => TokenKind::Compare,
+            "vs" | "versus" => TokenKind::Vs,
             // Russian: "от" means "of/from" in percent-of expressions (e.g. "38% от 100к").
             "от" => TokenKind::Of,
             // Russian: "в" means "in/into" (e.g. "1000 рублей в долларах")

--- a/src/grammar/linear_equation.rs
+++ b/src/grammar/linear_equation.rs
@@ -82,7 +82,8 @@ impl LinearForm {
             | Expression::Power { .. }
             | Expression::IndefiniteIntegral { .. }
             | Expression::UnitConversion { .. }
-            | Expression::Equality { .. } => Err(Self::unsupported_equation()),
+            | Expression::Equality { .. }
+            | Expression::Comparison { .. } => Err(Self::unsupported_equation()),
         }
     }
 

--- a/src/grammar/polynomial_equation.rs
+++ b/src/grammar/polynomial_equation.rs
@@ -81,7 +81,8 @@ impl PolynomialForm {
             | Expression::FunctionCall { .. }
             | Expression::IndefiniteIntegral { .. }
             | Expression::UnitConversion { .. }
-            | Expression::Equality { .. } => Err(Self::unsupported_equation()),
+            | Expression::Equality { .. }
+            | Expression::Comparison { .. } => Err(Self::unsupported_equation()),
         }
     }
 

--- a/src/grammar/token_parser.rs
+++ b/src/grammar/token_parser.rs
@@ -1,4 +1,5 @@
 //! Token-based expression parser.
+mod comparison;
 mod units;
 
 use crate::error::CalculatorError;
@@ -28,10 +29,6 @@ impl<'a> TokenParser<'a> {
         }
     }
 
-    pub fn parse_expression(&mut self) -> Result<Expression, CalculatorError> {
-        self.parse_equality()
-    }
-
     pub fn parse_complete_expression(&mut self) -> Result<Expression, CalculatorError> {
         let expr = self.parse_expression()?;
 
@@ -44,18 +41,6 @@ impl<'a> TokenParser<'a> {
             "Unexpected trailing input '{}' at position {}",
             token.text, token.start
         )))
-    }
-
-    fn parse_equality(&mut self) -> Result<Expression, CalculatorError> {
-        let left = self.parse_additive()?;
-
-        if self.check(&TokenKind::Equals) {
-            self.advance(); // consume '='
-            let right = self.parse_additive()?;
-            return Ok(Expression::equality(left, right));
-        }
-
-        Ok(left)
     }
 
     fn parse_additive(&mut self) -> Result<Expression, CalculatorError> {

--- a/src/grammar/token_parser/comparison.rs
+++ b/src/grammar/token_parser/comparison.rs
@@ -1,0 +1,64 @@
+use crate::error::CalculatorError;
+use crate::grammar::TokenKind;
+use crate::types::{ComparisonOp, Expression};
+
+use super::TokenParser;
+
+impl TokenParser<'_> {
+    pub fn parse_expression(&mut self) -> Result<Expression, CalculatorError> {
+        self.parse_comparison()
+    }
+
+    fn parse_comparison(&mut self) -> Result<Expression, CalculatorError> {
+        if self.check_compare() {
+            self.advance(); // consume "compare"
+            let left = self.parse_additive()?;
+            self.expect(&TokenKind::And)?;
+            let right = self.parse_additive()?;
+            return Ok(Expression::comparison(left, ComparisonOp::Compare, right));
+        }
+
+        let left = self.parse_additive()?;
+
+        if self.check_vs() {
+            self.advance(); // consume "vs"
+            let right = self.parse_additive()?;
+            return Ok(Expression::comparison(left, ComparisonOp::Compare, right));
+        }
+
+        if self.check(&TokenKind::Equals) {
+            self.advance(); // consume '=' or '=='
+            let right = self.parse_additive()?;
+            return Ok(Expression::equality(left, right));
+        }
+
+        if let Some(op) = self.match_ordering_op() {
+            let right = self.parse_additive()?;
+            return Ok(Expression::comparison(left, op, right));
+        }
+
+        Ok(left)
+    }
+
+    fn match_ordering_op(&mut self) -> Option<ComparisonOp> {
+        let op = match self.current_kind()? {
+            TokenKind::DoubleEquals => ComparisonOp::Equal,
+            TokenKind::Less => ComparisonOp::Less,
+            TokenKind::LessOrEqual => ComparisonOp::LessOrEqual,
+            TokenKind::Greater => ComparisonOp::Greater,
+            TokenKind::GreaterOrEqual => ComparisonOp::GreaterOrEqual,
+            TokenKind::NotEqual => ComparisonOp::NotEqual,
+            _ => return None,
+        };
+        self.advance();
+        Some(op)
+    }
+
+    fn check_compare(&self) -> bool {
+        matches!(self.current_kind(), Some(TokenKind::Compare))
+    }
+
+    fn check_vs(&self) -> bool {
+        matches!(self.current_kind(), Some(TokenKind::Vs))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,8 @@ pub mod types;
 pub mod utils;
 pub mod wasm;
 
+mod substitution;
+
 pub use plan::{CalculationPlan, RateSource};
 pub use utils::{generate_issue_link, truncate};
 
@@ -723,67 +725,6 @@ impl Calculator {
             .as_decimal()
             .map(|d| d.to_f64())
             .ok_or_else(|| CalculatorError::eval("Expected numeric result"))
-    }
-
-    /// Substitutes a variable with a numeric value in an expression.
-    fn substitute_variable(expr: &types::Expression, var: &str, value: f64) -> types::Expression {
-        use types::{Decimal, Expression};
-
-        match expr {
-            Expression::Variable(name) if name == var => {
-                Expression::number(Decimal::from_f64(value))
-            }
-            Expression::Variable(_)
-            | Expression::Number { .. }
-            | Expression::DateTime(_)
-            | Expression::Now => expr.clone(),
-            Expression::Until(inner) => {
-                Expression::Until(Box::new(Self::substitute_variable(inner, var, value)))
-            }
-            Expression::Binary { left, op, right } => Expression::binary(
-                Self::substitute_variable(left, var, value),
-                *op,
-                Self::substitute_variable(right, var, value),
-            ),
-            Expression::Negate(inner) => {
-                Expression::negate(Self::substitute_variable(inner, var, value))
-            }
-            Expression::Group(inner) => {
-                Expression::group(Self::substitute_variable(inner, var, value))
-            }
-            Expression::Power { base, exponent } => Expression::power(
-                Self::substitute_variable(base, var, value),
-                Self::substitute_variable(exponent, var, value),
-            ),
-            Expression::FunctionCall { name, args } => Expression::function_call(
-                name.clone(),
-                args.iter()
-                    .map(|a| Self::substitute_variable(a, var, value))
-                    .collect(),
-            ),
-            Expression::AtTime { value: v, time } => Expression::at_time(
-                Self::substitute_variable(v, var, value),
-                Self::substitute_variable(time, var, value),
-            ),
-            Expression::IndefiniteIntegral {
-                integrand,
-                variable,
-            } => Expression::indefinite_integral(
-                Self::substitute_variable(integrand, var, value),
-                variable.clone(),
-            ),
-            Expression::UnitConversion {
-                value: v,
-                target_unit,
-            } => Expression::unit_conversion(
-                Self::substitute_variable(v, var, value),
-                target_unit.clone(),
-            ),
-            Expression::Equality { left, right } => Expression::equality(
-                Self::substitute_variable(left, var, value),
-                Self::substitute_variable(right, var, value),
-            ),
-        }
     }
 
     /// Parses an expression without evaluating it.

--- a/src/substitution.rs
+++ b/src/substitution.rs
@@ -1,0 +1,72 @@
+use crate::types::{self, Decimal, Expression};
+use crate::Calculator;
+
+impl Calculator {
+    /// Substitutes a variable with a numeric value in an expression.
+    pub(super) fn substitute_variable(
+        expr: &types::Expression,
+        var: &str,
+        value: f64,
+    ) -> types::Expression {
+        match expr {
+            Expression::Variable(name) if name == var => {
+                Expression::number(Decimal::from_f64(value))
+            }
+            Expression::Variable(_)
+            | Expression::Number { .. }
+            | Expression::DateTime(_)
+            | Expression::Now => expr.clone(),
+            Expression::Until(inner) => {
+                Expression::Until(Box::new(Self::substitute_variable(inner, var, value)))
+            }
+            Expression::Binary { left, op, right } => Expression::binary(
+                Self::substitute_variable(left, var, value),
+                *op,
+                Self::substitute_variable(right, var, value),
+            ),
+            Expression::Negate(inner) => {
+                Expression::negate(Self::substitute_variable(inner, var, value))
+            }
+            Expression::Group(inner) => {
+                Expression::group(Self::substitute_variable(inner, var, value))
+            }
+            Expression::Power { base, exponent } => Expression::power(
+                Self::substitute_variable(base, var, value),
+                Self::substitute_variable(exponent, var, value),
+            ),
+            Expression::FunctionCall { name, args } => Expression::function_call(
+                name.clone(),
+                args.iter()
+                    .map(|a| Self::substitute_variable(a, var, value))
+                    .collect(),
+            ),
+            Expression::AtTime { value: v, time } => Expression::at_time(
+                Self::substitute_variable(v, var, value),
+                Self::substitute_variable(time, var, value),
+            ),
+            Expression::IndefiniteIntegral {
+                integrand,
+                variable,
+            } => Expression::indefinite_integral(
+                Self::substitute_variable(integrand, var, value),
+                variable.clone(),
+            ),
+            Expression::UnitConversion {
+                value: v,
+                target_unit,
+            } => Expression::unit_conversion(
+                Self::substitute_variable(v, var, value),
+                target_unit.clone(),
+            ),
+            Expression::Equality { left, right } => Expression::equality(
+                Self::substitute_variable(left, var, value),
+                Self::substitute_variable(right, var, value),
+            ),
+            Expression::Comparison { left, op, right } => Expression::comparison(
+                Self::substitute_variable(left, var, value),
+                *op,
+                Self::substitute_variable(right, var, value),
+            ),
+        }
+    }
+}

--- a/src/types/expression.rs
+++ b/src/types/expression.rs
@@ -44,6 +44,47 @@ impl fmt::Display for BinaryOp {
     }
 }
 
+/// A comparison operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ComparisonOp {
+    /// Equal (`==`).
+    Equal,
+    /// Strictly less than (`<`).
+    Less,
+    /// Less than or equal (`<=`).
+    LessOrEqual,
+    /// Strictly greater than (`>`).
+    Greater,
+    /// Greater than or equal (`>=`).
+    GreaterOrEqual,
+    /// Not equal (`!=`).
+    NotEqual,
+    /// Generic comparison (`compare a and b`, `a vs b`).
+    Compare,
+}
+
+impl ComparisonOp {
+    /// Returns the symbol for the comparison operation.
+    #[must_use]
+    pub fn symbol(&self) -> &'static str {
+        match self {
+            Self::Equal => "==",
+            Self::Less => "<",
+            Self::LessOrEqual => "<=",
+            Self::Greater => ">",
+            Self::GreaterOrEqual => ">=",
+            Self::NotEqual => "!=",
+            Self::Compare => "compare",
+        }
+    }
+}
+
+impl fmt::Display for ComparisonOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.symbol())
+    }
+}
+
 /// An expression in the calculator grammar.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Expression {
@@ -104,6 +145,15 @@ pub enum Expression {
     Equality {
         /// The left-hand side expression.
         left: Box<Expression>,
+        /// The right-hand side expression.
+        right: Box<Expression>,
+    },
+    /// Value comparison expression (e.g., `1 < 2`, `compare 1 and 2`).
+    Comparison {
+        /// The left-hand side expression.
+        left: Box<Expression>,
+        /// The comparison operator.
+        op: ComparisonOp,
         /// The right-hand side expression.
         right: Box<Expression>,
     },
@@ -236,6 +286,16 @@ impl Expression {
         }
     }
 
+    /// Creates a comparison expression (e.g., `1 < 2`).
+    #[must_use]
+    pub fn comparison(left: Expression, op: ComparisonOp, right: Expression) -> Self {
+        Self::Comparison {
+            left: Box::new(left),
+            op,
+            right: Box::new(right),
+        }
+    }
+
     /// Converts the expression to links notation format.
     ///
     /// Links notation wraps all compound expressions in parentheses:
@@ -331,6 +391,15 @@ impl Expression {
                 let right_str = right.to_lino_internal(None);
                 format!("({left_str} = {right_str})")
             }
+            Self::Comparison { left, op, right } => {
+                let left_str = left.to_lino_internal(None);
+                let right_str = right.to_lino_internal(None);
+                if *op == ComparisonOp::Compare {
+                    format!("(compare {left_str} {right_str})")
+                } else {
+                    format!("({left_str} {op} {right_str})")
+                }
+            }
         }
     }
 
@@ -411,6 +480,10 @@ impl Expression {
                     arg.collect_alternatives(alternatives);
                 }
             }
+            Self::Equality { left, right } | Self::Comparison { left, right, .. } => {
+                left.collect_alternatives(alternatives);
+                right.collect_alternatives(alternatives);
+            }
             _ => {}
         }
     }
@@ -470,7 +543,10 @@ impl Expression {
     fn needs_parens_for_unary(&self) -> bool {
         matches!(
             self,
-            Self::Binary { .. } | Self::AtTime { .. } | Self::UnitConversion { .. }
+            Self::Binary { .. }
+                | Self::AtTime { .. }
+                | Self::UnitConversion { .. }
+                | Self::Comparison { .. }
         )
     }
 
@@ -519,7 +595,7 @@ impl Expression {
                 base.contains_live_time() || exponent.contains_live_time()
             }
             Self::UnitConversion { value, .. } => value.contains_live_time(),
-            Self::Equality { left, right } => {
+            Self::Equality { left, right } | Self::Comparison { left, right, .. } => {
                 left.contains_live_time() || right.contains_live_time()
             }
             Self::IndefiniteIntegral { integrand, .. } => integrand.contains_live_time(),
@@ -551,7 +627,8 @@ impl Expression {
                 base: left,
                 exponent: right,
             }
-            | Self::Equality { left, right } => {
+            | Self::Equality { left, right }
+            | Self::Comparison { left, right, .. } => {
                 left.collect_currencies_inner(currencies);
                 right.collect_currencies_inner(currencies);
             }
@@ -589,7 +666,8 @@ impl Expression {
             | Self::Power {
                 base: left,
                 exponent: right,
-            } => 1 + left.depth().max(right.depth()),
+            }
+            | Self::Comparison { left, right, .. } => 1 + left.depth().max(right.depth()),
             Self::Negate(inner) | Self::Group(inner) | Self::Until(inner) => 1 + inner.depth(),
             Self::AtTime { value, time } => 1 + value.depth().max(time.depth()),
             Self::FunctionCall { args, .. } => {
@@ -738,6 +816,27 @@ impl Expression {
             Self::Equality { left, right } => {
                 format!("{} = {}", left.to_latex(), right.to_latex())
             }
+            Self::Comparison { left, op, right } => {
+                let latex_op = match op {
+                    ComparisonOp::Less => "<",
+                    ComparisonOp::Equal => "=",
+                    ComparisonOp::LessOrEqual => "\\le",
+                    ComparisonOp::Greater => ">",
+                    ComparisonOp::GreaterOrEqual => "\\ge",
+                    ComparisonOp::NotEqual => "\\ne",
+                    ComparisonOp::Compare => "\\operatorname{compare}",
+                };
+                if *op == ComparisonOp::Compare {
+                    format!(
+                        "{}\\left({}, {}\\right)",
+                        latex_op,
+                        left.to_latex(),
+                        right.to_latex()
+                    )
+                } else {
+                    format!("{} {} {}", left.to_latex(), latex_op, right.to_latex())
+                }
+            }
         }
     }
 }
@@ -779,6 +878,13 @@ impl fmt::Display for Expression {
                 write!(f, "{value} as {target_unit}")
             }
             Self::Equality { left, right } => write!(f, "{left} = {right}"),
+            Self::Comparison { left, op, right } => {
+                if *op == ComparisonOp::Compare {
+                    write!(f, "compare {left} and {right}")
+                } else {
+                    write!(f, "{left} {op} {right}")
+                }
+            }
         }
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -11,7 +11,7 @@ mod value;
 pub use currency::{Currency, CurrencyDatabase, ExchangeRateInfo};
 pub use datetime::{DateTime, DateTimeResult};
 pub use decimal::Decimal;
-pub use expression::{BinaryOp, Expression};
+pub use expression::{BinaryOp, ComparisonOp, Expression};
 pub use rational::{Rational, RepeatingDecimal};
 pub use unit::{DataSizeUnit, DurationUnit, MassUnit, Unit};
 pub use value::{Value, ValueKind};

--- a/src/types/value/kind.rs
+++ b/src/types/value/kind.rs
@@ -18,6 +18,15 @@ pub enum ValueKind {
     },
     /// A boolean value.
     Boolean(bool),
+    /// A generic comparison result such as `1 < 2`.
+    Comparison {
+        /// Display string for the left value.
+        left: String,
+        /// Relation symbol (`<`, `>`, or `=`).
+        relation: String,
+        /// Display string for the right value.
+        right: String,
+    },
     /// A solved single-variable equation.
     EquationSolution {
         /// The solved variable name.

--- a/src/types/value/mod.rs
+++ b/src/types/value/mod.rs
@@ -111,6 +111,23 @@ impl Value {
         }
     }
 
+    /// Creates a generic comparison result value.
+    #[must_use]
+    pub fn comparison_result(
+        left: impl Into<String>,
+        relation: impl Into<String>,
+        right: impl Into<String>,
+    ) -> Self {
+        Self {
+            kind: ValueKind::Comparison {
+                left: left.into(),
+                relation: relation.into(),
+                right: right.into(),
+            },
+            unit: Unit::None,
+        }
+    }
+
     /// Creates a solved equation value.
     #[must_use]
     pub fn equation_solution(variable: impl Into<String>, value: Rational) -> Self {
@@ -830,6 +847,7 @@ impl Value {
             ValueKind::DateTime(_) => "datetime",
             ValueKind::Duration { .. } => "duration",
             ValueKind::Boolean(_) => "boolean",
+            ValueKind::Comparison { .. } => "comparison result",
             ValueKind::EquationSolution { .. }
             | ValueKind::EquationSolutions { .. }
             | ValueKind::SymbolicEquationSolution { .. } => "equation solution",
@@ -859,6 +877,11 @@ impl Value {
             ValueKind::DateTime(dt) => dt.to_string(),
             ValueKind::Duration { seconds } => format_duration(*seconds),
             ValueKind::Boolean(b) => b.to_string(),
+            ValueKind::Comparison {
+                left,
+                relation,
+                right,
+            } => format!("{left} {relation} {right}"),
             ValueKind::EquationSolution { variable, value } => {
                 format!("{variable} = {}", value.to_display_string())
             }

--- a/tests/issue_183_comparison_tests.rs
+++ b/tests/issue_183_comparison_tests.rs
@@ -1,0 +1,130 @@
+//! Regression tests for issue #183 and its comparison syntax sub-issues.
+//!
+//! The calculator should recognize explicit ordering operators and natural
+//! comparison forms instead of treating them as unrecognized input.
+
+use link_calculator::Calculator;
+
+fn calculate(input: &str) -> link_calculator::CalculationResult {
+    Calculator::new().calculate_internal(input)
+}
+
+#[test]
+fn issue_181_less_than_operator_compares_values() {
+    let result = calculate("1781293631682 < 1781299013388");
+
+    assert!(
+        result.success,
+        "less-than comparison should succeed, got error: {:?}",
+        result.error
+    );
+    assert_eq!(result.result, "true");
+    assert_eq!(
+        result.lino_interpretation,
+        "(1781293631682 < 1781299013388)"
+    );
+}
+
+#[test]
+fn issue_180_greater_than_operator_compares_values() {
+    let result = calculate("1781293631682 > 1781299013388");
+
+    assert!(
+        result.success,
+        "greater-than comparison should succeed, got error: {:?}",
+        result.error
+    );
+    assert_eq!(result.result, "false");
+    assert_eq!(
+        result.lino_interpretation,
+        "(1781293631682 > 1781299013388)"
+    );
+}
+
+#[test]
+fn issue_179_compare_keyword_reports_ordering() {
+    let result = calculate("compare 1781293631682 and 1781299013388");
+
+    assert!(
+        result.success,
+        "compare keyword should succeed, got error: {:?}",
+        result.error
+    );
+    assert_eq!(
+        result.result, "1781293631682 < 1781299013388",
+        "generic comparison should report the relation, got steps: {:?}",
+        result.steps
+    );
+    assert_eq!(
+        result.lino_interpretation,
+        "(compare 1781293631682 1781299013388)"
+    );
+}
+
+#[test]
+fn issue_178_vs_keyword_reports_ordering() {
+    let result = calculate("1781293631682 vs 1781299013388");
+
+    assert!(
+        result.success,
+        "vs comparison should succeed, got error: {:?}",
+        result.error
+    );
+    assert_eq!(result.result, "1781293631682 < 1781299013388");
+    assert_eq!(
+        result.lino_interpretation,
+        "(compare 1781293631682 1781299013388)"
+    );
+}
+
+#[test]
+fn comparison_operators_cover_common_assertions() {
+    for (input, expected) in [
+        ("2 <= 2", "true"),
+        ("2 >= 3", "false"),
+        ("2 != 3", "true"),
+        ("2 == 2", "true"),
+        ("2 kg == 2000 g", "true"),
+        ("2 kg != 2000 g", "false"),
+    ] {
+        let result = calculate(input);
+        assert!(
+            result.success,
+            "{input} should succeed, got error: {:?}",
+            result.error
+        );
+        assert_eq!(result.result, expected, "{input}");
+    }
+}
+
+#[test]
+fn comparisons_work_after_arithmetic_precedence() {
+    let result = calculate("1 + 2 * 3 > 6");
+
+    assert!(
+        result.success,
+        "arithmetic comparison should succeed, got error: {:?}",
+        result.error
+    );
+    assert_eq!(result.result, "true");
+    assert_eq!(result.lino_interpretation, "((1 + (2 * 3)) > 6)");
+}
+
+#[test]
+fn comparisons_normalize_compatible_units() {
+    let greater = calculate("2 kg > 1500 g");
+    assert!(
+        greater.success,
+        "mass comparison should succeed, got error: {:?}",
+        greater.error
+    );
+    assert_eq!(greater.result, "true");
+
+    let generic = calculate("compare 3 days and 72 hours");
+    assert!(
+        generic.success,
+        "duration comparison should succeed, got error: {:?}",
+        generic.error
+    );
+    assert_eq!(generic.result, "3 days = 72 hours");
+}

--- a/web/src/i18n/index.test.ts
+++ b/web/src/i18n/index.test.ts
@@ -56,6 +56,7 @@ const REQUIRED_USER_OUTPUT_KEYS = [
   'steps.solution',
   'steps.checkEquality',
   'steps.compare',
+  'steps.compareOperator',
 ] as const;
 
 function flattenTranslations(

--- a/web/src/i18n/locales/ar.lino
+++ b/web/src/i18n/locales/ar.lino
@@ -90,6 +90,7 @@ steps:
   solution 'الحل: {{value}}'
   checkEquality 'التحقق من المساواة:'
   compare 'مقارنة: {{left}} = {{right}}'
+  compareOperator 'مقارنة: {{left}} {{op}} {{right}}'
 issueReport:
   environment البيئة
   version الإصدار

--- a/web/src/i18n/locales/de.lino
+++ b/web/src/i18n/locales/de.lino
@@ -90,6 +90,7 @@ steps:
   solution 'Lösung: {{value}}'
   checkEquality 'Gleichheit prüfen:'
   compare 'Vergleichen: {{left}} = {{right}}'
+  compareOperator 'Vergleichen: {{left}} {{op}} {{right}}'
 issueReport:
   environment Umgebung
   version Version

--- a/web/src/i18n/locales/en.lino
+++ b/web/src/i18n/locales/en.lino
@@ -90,6 +90,7 @@ steps:
   solution 'Solution: {{value}}'
   checkEquality 'Check equality:'
   compare 'Compare: {{left}} = {{right}}'
+  compareOperator 'Compare: {{left}} {{op}} {{right}}'
 issueReport:
   environment Environment
   version Version

--- a/web/src/i18n/locales/fr.lino
+++ b/web/src/i18n/locales/fr.lino
@@ -90,6 +90,7 @@ steps:
   solution 'Solution : {{value}}'
   checkEquality "Vérifier l'égalité :"
   compare 'Comparer : {{left}} = {{right}}'
+  compareOperator 'Comparer : {{left}} {{op}} {{right}}'
 issueReport:
   environment Environnement
   version Version

--- a/web/src/i18n/locales/hi.lino
+++ b/web/src/i18n/locales/hi.lino
@@ -90,6 +90,7 @@ steps:
   solution 'हल: {{value}}'
   checkEquality 'समानता जाँचें:'
   compare 'तुलना करें: {{left}} = {{right}}'
+  compareOperator 'तुलना करें: {{left}} {{op}} {{right}}'
 issueReport:
   environment वातावरण
   version संस्करण

--- a/web/src/i18n/locales/ru.lino
+++ b/web/src/i18n/locales/ru.lino
@@ -90,6 +90,7 @@ steps:
   solution 'Решение: {{value}}'
   checkEquality 'Проверить равенство:'
   compare 'Сравнить: {{left}} = {{right}}'
+  compareOperator 'Сравнить: {{left}} {{op}} {{right}}'
 issueReport:
   environment Окружение
   version Версия

--- a/web/src/i18n/locales/zh.lino
+++ b/web/src/i18n/locales/zh.lino
@@ -90,6 +90,7 @@ steps:
   solution '解：{{value}}'
   checkEquality 检查相等性：
   compare '比较：{{left}} = {{right}}'
+  compareOperator '比较：{{left}} {{op}} {{right}}'
 issueReport:
   environment 环境
   version 版本

--- a/web/src/utils/localizeCalculation.test.ts
+++ b/web/src/utils/localizeCalculation.test.ts
@@ -23,6 +23,7 @@ describe('calculation step localization', () => {
     'steps.equals': '= {{value}}',
     'steps.evaluateGroup': 'Вычислить сгруппированное выражение:',
     'steps.finalResult': 'Итоговый результат: {{value}}',
+    'steps.compareOperator': 'Сравнить: {{left}} {{op}} {{right}}',
   });
 
   it('should translate raw arithmetic steps from issue 171', () => {
@@ -63,5 +64,11 @@ describe('calculation step localization', () => {
     };
 
     expect(localizeCalculationSteps(ruT, result)).toEqual(['Входное выражение: 2 + 3']);
+  });
+
+  it('should translate raw comparison operator steps', () => {
+    expect(translateCalculationStep(ruT, 'Compare: 1 < 2')).toBe('Сравнить: 1 < 2');
+    expect(translateCalculationStep(ruT, 'Compare: 1 == 1')).toBe('Сравнить: 1 == 1');
+    expect(translateCalculationStep(ruT, 'Compare: 1 vs 2')).toBe('Сравнить: 1 vs 2');
   });
 });

--- a/web/src/utils/localizeCalculation.ts
+++ b/web/src/utils/localizeCalculation.ts
@@ -229,6 +229,13 @@ function parseRawCalculationStep(step: string): ParsedCalculationStep | null {
       }),
     },
     {
+      regex: /^Compare: (.+) (==|<=|>=|!=|<|>|vs) (.+)$/,
+      build: match => ({
+        key: 'steps.compareOperator',
+        params: { left: match[1], op: match[2], right: match[3] },
+      }),
+    },
+    {
       regex: /^Compare: (.+) = (.+)$/,
       build: match => ({
         key: 'steps.compare',


### PR DESCRIPTION
## Summary
- Add parser and evaluator support for explicit comparison syntax: `<`, `>`, `<=`, `>=`, `!=`, and `==`.
- Add natural comparison forms for `compare A and B`, `A vs B`, and `A versus B`, returning the detected relation for generic comparisons.
- Normalize compatible units before comparison, so cases like `2 kg > 1500 g` and `compare 3 days and 72 hours` work.
- Add localized UI step handling for comparison operator traces across all supported locale files.

## Reproduction
Before this PR, the comparison issue examples failed during parsing:

```text
1781293631682 vs 1781299013388
compare 1781293631682 and 1781299013388
1781293631682 > 1781299013388
1781293631682 < 1781299013388
```

After this change, `vs` and `compare ... and ...` report the relation (`1781293631682 < 1781299013388`), while explicit operators return boolean comparison results.

## Tests
- `cargo test --test issue_183_comparison_tests`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo test --all-features --verbose`
- `cargo test --doc --verbose`
- `node scripts/check-file-size.mjs`
- `node scripts/check-changelog-fragment.mjs`
- `wasm-pack build --target web --out-dir web/public/pkg`
- `cd web && npm ci`
- `cd web && npx tsc --noEmit`
- `cd web && npm test`
- `cd web && npm run build`

Fixes #183
Fixes #178
Fixes #179
Fixes #180
Fixes #181
