### PR TITLE
fix: interpret `now` and bare times in local timezone (#185)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-17T16:24:52.158Z for PR creation at branch issue-185-5c2838a97727 for issue https://github.com/link-assistant/calculator/issues/185

--- a/changelog.d/20260617_120000_local_timezone_now.md
+++ b/changelog.d/20260617_120000_local_timezone_now.md
@@ -1,0 +1,16 @@
+---
+bump: minor
+---
+
+### Fixed
+- `now-12:30` and similar `DateTime - DateTime` subtractions no longer collapse a
+  negative difference to `0 seconds`; the signed duration is now returned
+  (issue #185).
+
+### Added
+- The web app now interprets `now` and timezone-less times (e.g. `12:30`) in the
+  user's local timezone by default, so `now-12:30` matches the wall clock.
+  Times with an explicit timezone (e.g. `12:30 UTC`) are still honored as given.
+- New `Calculator::set_timezone_offset(offset_minutes)` and
+  `Calculator::clear_timezone_offset()` WASM/library methods to control the
+  local timezone offset used when resolving `now` and bare times.

--- a/src/grammar/datetime_grammar.rs
+++ b/src/grammar/datetime_grammar.rs
@@ -277,11 +277,30 @@ impl DateTimeGrammar {
         None
     }
 
+    /// Localizes a parsed datetime to the user's local timezone, when one is known.
+    ///
+    /// A bare `now` becomes the current local time; bare (timezone-less) times are
+    /// re-anchored to the local offset. Inputs with an explicit timezone, and the
+    /// explicit `now utc` / `now <tz>` forms, are returned unchanged.
+    fn localize(dt: DateTime, raw: &str, offset: Option<i32>) -> DateTime {
+        let Some(offset) = offset else {
+            return dt;
+        };
+        if raw.trim().eq_ignore_ascii_case("now") {
+            return DateTime::now_local(offset);
+        }
+        dt.reinterpret_naive_as_local(offset)
+    }
+
     /// Tries to parse a datetime subtraction expression like "(Jan 27, 8:59am UTC) - (Jan 25, 12:51pm UTC)".
+    ///
+    /// `local_offset` is the user's timezone offset in seconds east of UTC, when
+    /// known; it makes bare `now` and timezone-less times resolve to local time.
     #[must_use]
     pub fn try_parse_datetime_subtraction(
         &self,
         input: &str,
+        local_offset: Option<i32>,
     ) -> Option<(Value, Vec<String>, String)> {
         // Look for pattern: (datetime) - (datetime)
         let input = input.trim();
@@ -292,6 +311,8 @@ impl DateTimeGrammar {
 
         if let Some((left, right)) = input.split_once(" - ") {
             if let (Ok(dt1), Ok(dt2)) = (self.parse(left.trim()), self.parse(right.trim())) {
+                let dt1 = Self::localize(dt1, left.trim(), local_offset);
+                let dt2 = Self::localize(dt2, right.trim(), local_offset);
                 return Some(Self::datetime_difference_result(
                     &dt1,
                     &dt2,
@@ -352,6 +373,9 @@ impl DateTimeGrammar {
             return None;
         };
 
+        let dt1 = Self::localize(dt1, first_dt_str.trim(), local_offset);
+        let dt2 = Self::localize(dt2, second_dt_str.trim(), local_offset);
+
         Some(Self::datetime_difference_result(
             &dt1,
             &dt2,
@@ -366,10 +390,10 @@ impl DateTimeGrammar {
         first_dt_str: &str,
         second_dt_str: &str,
     ) -> (Value, Vec<String>, String) {
-        // Calculate the difference
-        let diff = dt1.subtract(dt2);
-        #[allow(clippy::cast_possible_wrap)]
-        let seconds = diff.as_secs() as i64;
+        // Calculate the signed difference (dt1 - dt2). Using signed seconds keeps
+        // the result correct when dt1 is earlier than dt2 (a negative duration),
+        // instead of collapsing to zero.
+        let seconds = dt1.signed_subtract_seconds(dt2);
 
         let value = Value::duration(seconds);
 

--- a/src/grammar/expression_parser.rs
+++ b/src/grammar/expression_parser.rs
@@ -111,9 +111,7 @@ impl ExpressionParser {
     fn current_now(&self) -> DateTime {
         match self.local_offset_seconds {
             Some(offset) => DateTime::now_local(offset),
-            None => {
-                DateTime::now_with_label("current UTC time", Some(0), Some("UTC".to_string()))
-            }
+            None => DateTime::now_with_label("current UTC time", Some(0), Some("UTC".to_string())),
         }
     }
 

--- a/src/grammar/expression_parser.rs
+++ b/src/grammar/expression_parser.rs
@@ -72,6 +72,12 @@ pub struct ExpressionParser {
     currency_db: CurrencyDatabase,
     /// Current date context for historical currency conversions (set by AtTime expressions).
     current_date_context: Option<DateTime>,
+    /// The user's local timezone offset in seconds east of UTC, when known.
+    ///
+    /// When set, `now` and bare (timezone-less) times such as `12:30` are
+    /// interpreted in this local timezone instead of UTC. Explicit timezones
+    /// (e.g. `12:30 UTC`) are always honored regardless of this setting.
+    local_offset_seconds: Option<i32>,
 }
 
 impl ExpressionParser {
@@ -83,6 +89,31 @@ impl ExpressionParser {
             datetime_grammar: DateTimeGrammar::new(),
             currency_db: CurrencyDatabase::new(),
             current_date_context: None,
+            local_offset_seconds: None,
+        }
+    }
+
+    /// Sets the user's local timezone offset in seconds east of UTC.
+    ///
+    /// Pass `None` to fall back to the default UTC interpretation.
+    pub fn set_local_offset_seconds(&mut self, offset_seconds: Option<i32>) {
+        self.local_offset_seconds = offset_seconds;
+    }
+
+    /// Returns the configured local timezone offset in seconds east of UTC, if any.
+    #[must_use]
+    pub fn local_offset_seconds(&self) -> Option<i32> {
+        self.local_offset_seconds
+    }
+
+    /// Returns a `DateTime` representing the current instant, honoring the
+    /// configured local timezone offset when one is set.
+    fn current_now(&self) -> DateTime {
+        match self.local_offset_seconds {
+            Some(offset) => DateTime::now_local(offset),
+            None => {
+                DateTime::now_with_label("current UTC time", Some(0), Some("UTC".to_string()))
+            }
         }
     }
 
@@ -110,7 +141,10 @@ impl ExpressionParser {
         self.currency_db.clear_last_used_rate();
 
         // Try datetime subtraction pattern first: "(datetime) - (datetime)"
-        if let Some(result) = self.datetime_grammar.try_parse_datetime_subtraction(input) {
+        if let Some(result) = self
+            .datetime_grammar
+            .try_parse_datetime_subtraction(input, self.local_offset_seconds)
+        {
             return Ok(result);
         }
 
@@ -131,7 +165,13 @@ impl ExpressionParser {
         let mut lexer = Lexer::new(input);
         let tokens = lexer.tokenize()?;
         let mut parser = TokenParser::new(&tokens, &self.number_grammar, input);
-        parser.parse_complete_expression()
+        let mut expr = parser.parse_complete_expression()?;
+        // Re-anchor timezone-less datetime literals to the user's local timezone
+        // when it is known, so bare times like `12:30` mean local time.
+        if let Some(offset) = self.local_offset_seconds {
+            expr.apply_local_offset(offset);
+        }
+        Ok(expr)
     }
 
     /// Evaluates an expression.
@@ -214,14 +254,10 @@ impl ExpressionParser {
                 Ok(Value::rational_with_unit(rational, unit.clone()))
             }
             Expression::DateTime(dt) => Ok(Value::datetime(dt.clone())),
-            Expression::Now => Ok(Value::datetime(DateTime::now_with_label(
-                "current UTC time",
-                Some(0),
-                Some("UTC".to_string()),
-            ))),
+            Expression::Now => Ok(Value::datetime(self.current_now())),
             Expression::Until(target) => {
                 let target_val = self.evaluate_expr(target)?;
-                let now = DateTime::now();
+                let now = self.current_now();
                 match &target_val.kind {
                     ValueKind::DateTime(target_dt) => {
                         let seconds = target_dt.signed_subtract_seconds(&now);
@@ -358,7 +394,7 @@ impl ExpressionParser {
                 }
                 let dt_val = Value::datetime(dt.clone());
                 // For standalone datetime, show time from now
-                let now = DateTime::now();
+                let now = self.current_now();
                 let seconds = dt.signed_subtract_seconds(&now);
                 if seconds > 0 {
                     steps.push(format!(
@@ -374,14 +410,13 @@ impl ExpressionParser {
                 Ok(dt_val)
             }
             Expression::Now => {
-                let now =
-                    DateTime::now_with_label("current UTC time", Some(0), Some("UTC".to_string()));
+                let now = self.current_now();
                 steps.push(format!("Current time: {now}"));
                 Ok(Value::datetime(now))
             }
             Expression::Until(target) => {
                 let target_val = self.evaluate_expr_with_steps(target, steps)?;
-                let now = DateTime::now();
+                let now = self.current_now();
                 match &target_val.kind {
                     ValueKind::DateTime(target_dt) => {
                         let seconds = target_dt.signed_subtract_seconds(&now);
@@ -889,14 +924,10 @@ impl ExpressionParser {
                 Ok(Value::rational_with_unit(rational, unit.clone()))
             }
             Expression::DateTime(dt) => Ok(Value::datetime(dt.clone())),
-            Expression::Now => Ok(Value::datetime(DateTime::now_with_label(
-                "current UTC time",
-                Some(0),
-                Some("UTC".to_string()),
-            ))),
+            Expression::Now => Ok(Value::datetime(self.current_now())),
             Expression::Until(target) => {
                 let target_val = self.evaluate_expr_with_var(target, var_name, var_value)?;
-                let now = DateTime::now();
+                let now = self.current_now();
                 match &target_val.kind {
                     ValueKind::DateTime(target_dt) => {
                         let seconds = target_dt.signed_subtract_seconds(&now);

--- a/src/grammar/expression_parser.rs
+++ b/src/grammar/expression_parser.rs
@@ -13,6 +13,11 @@ use crate::types::{
 };
 use std::cmp::Ordering;
 
+// Local-timezone handling for `now` and bare times lives in a child module so it
+// can access `ExpressionParser`'s private fields while keeping this file small.
+#[path = "expression_parser_timezone.rs"]
+mod timezone;
+
 /// Evaluates a power expression, using exact rational arithmetic when possible.
 ///
 /// When both base and exponent are rational and the exponent is an integer
@@ -90,28 +95,6 @@ impl ExpressionParser {
             currency_db: CurrencyDatabase::new(),
             current_date_context: None,
             local_offset_seconds: None,
-        }
-    }
-
-    /// Sets the user's local timezone offset in seconds east of UTC.
-    ///
-    /// Pass `None` to fall back to the default UTC interpretation.
-    pub fn set_local_offset_seconds(&mut self, offset_seconds: Option<i32>) {
-        self.local_offset_seconds = offset_seconds;
-    }
-
-    /// Returns the configured local timezone offset in seconds east of UTC, if any.
-    #[must_use]
-    pub fn local_offset_seconds(&self) -> Option<i32> {
-        self.local_offset_seconds
-    }
-
-    /// Returns a `DateTime` representing the current instant, honoring the
-    /// configured local timezone offset when one is set.
-    fn current_now(&self) -> DateTime {
-        match self.local_offset_seconds {
-            Some(offset) => DateTime::now_local(offset),
-            None => DateTime::now_with_label("current UTC time", Some(0), Some("UTC".to_string())),
         }
     }
 

--- a/src/grammar/expression_parser_timezone.rs
+++ b/src/grammar/expression_parser_timezone.rs
@@ -1,0 +1,36 @@
+//! Local-timezone handling for [`ExpressionParser`].
+//!
+//! When the user's local timezone offset is configured, `now` and bare
+//! (timezone-less) times such as `12:30` are interpreted in that timezone
+//! instead of UTC. Inputs with an explicit timezone (e.g. `12:30 UTC`) are
+//! always honored regardless of this setting.
+//!
+//! This is a child module of `expression_parser`, so these `impl` blocks can
+//! access `ExpressionParser`'s private `local_offset_seconds` field.
+
+use super::ExpressionParser;
+use crate::types::DateTime;
+
+impl ExpressionParser {
+    /// Sets the user's local timezone offset in seconds east of UTC.
+    ///
+    /// Pass `None` to fall back to the default UTC interpretation.
+    pub fn set_local_offset_seconds(&mut self, offset_seconds: Option<i32>) {
+        self.local_offset_seconds = offset_seconds;
+    }
+
+    /// Returns the configured local timezone offset in seconds east of UTC, if any.
+    #[must_use]
+    pub fn local_offset_seconds(&self) -> Option<i32> {
+        self.local_offset_seconds
+    }
+
+    /// Returns a `DateTime` representing the current instant, honoring the
+    /// configured local timezone offset when one is set.
+    pub(super) fn current_now(&self) -> DateTime {
+        match self.local_offset_seconds {
+            Some(offset) => DateTime::now_local(offset),
+            None => DateTime::now_with_label("current UTC time", Some(0), Some("UTC".to_string())),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -466,6 +466,28 @@ impl Calculator {
         self.execute(input)
     }
 
+    /// Sets the user's local timezone offset, in minutes east of UTC.
+    ///
+    /// From the browser, pass `-new Date().getTimezoneOffset()` (note the sign:
+    /// `getTimezoneOffset()` returns minutes *behind* UTC, so it must be negated).
+    /// For example, UTC+5:30 (India) is `330`, and UTC-5 (US Eastern) is `-300`.
+    ///
+    /// Once set, bare times such as `12:30` and the `now` keyword are interpreted
+    /// in this local timezone instead of UTC. Inputs with an explicit timezone
+    /// (e.g. `12:30 UTC`, `now UTC`) are always honored regardless of this setting.
+    #[wasm_bindgen]
+    pub fn set_timezone_offset(&mut self, offset_minutes: i32) {
+        self.parser
+            .set_local_offset_seconds(Some(offset_minutes * 60));
+    }
+
+    /// Clears any previously configured local timezone offset, restoring the
+    /// default UTC interpretation for `now` and bare times.
+    #[wasm_bindgen]
+    pub fn clear_timezone_offset(&mut self) {
+        self.parser.set_local_offset_seconds(None);
+    }
+
     /// Returns the version of the calculator.
     #[wasm_bindgen]
     #[must_use]

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -127,6 +127,52 @@ impl DateTime {
         }
     }
 
+    /// Creates a `DateTime` for the current instant, displayed in the user's
+    /// local timezone given by `offset_seconds` (seconds east of UTC).
+    ///
+    /// The internal instant is still the true current UTC time; only the display
+    /// offset and label differ from [`Self::now`]. Used when the calculator is
+    /// told the user's local timezone so that `now` reflects their wall clock
+    /// instead of UTC.
+    #[must_use]
+    pub fn now_local(offset_seconds: i32) -> Self {
+        Self {
+            inner: Utc::now(),
+            offset_seconds: Some(offset_seconds),
+            has_time: true,
+            has_date: true,
+            label: Some("current local time".to_string()),
+            tz_abbrev: None,
+        }
+    }
+
+    /// Re-anchors a timezone-less ("naive") time or datetime to a local timezone.
+    ///
+    /// Bare times like `12:30` are parsed with their wall-clock reading stored as
+    /// if it were UTC. When the user's local timezone is known, the same
+    /// wall-clock reading should instead be interpreted as local time. This shifts
+    /// the internal UTC instant back by `offset_seconds` so the displayed wall
+    /// clock is preserved while the underlying instant becomes correct for the
+    /// local timezone.
+    ///
+    /// Values that already carry an explicit timezone (e.g. `12:30 UTC`) or that
+    /// have no time component (plain dates) are returned unchanged.
+    #[must_use]
+    pub fn reinterpret_naive_as_local(&self, offset_seconds: i32) -> Self {
+        if self.offset_seconds.is_some() || !self.has_time {
+            return self.clone();
+        }
+        let adjusted = self.inner - Duration::seconds(i64::from(offset_seconds));
+        Self {
+            inner: adjusted,
+            offset_seconds: Some(offset_seconds),
+            has_time: self.has_time,
+            has_date: self.has_date,
+            label: self.label.clone(),
+            tz_abbrev: None,
+        }
+    }
+
     /// Returns whether this datetime has a label (i.e., represents a named live time expression).
     #[must_use]
     pub fn is_live_time(&self) -> bool {

--- a/src/types/expression.rs
+++ b/src/types/expression.rs
@@ -308,6 +308,46 @@ impl Expression {
         self.to_lino_internal(None)
     }
 
+    /// Recursively re-anchors timezone-less datetime literals in this expression
+    /// to the user's local timezone, given by `offset_seconds` (seconds east of UTC).
+    ///
+    /// See [`DateTime::reinterpret_naive_as_local`]. `now` is resolved at
+    /// evaluation time, so it is intentionally left untouched here.
+    pub fn apply_local_offset(&mut self, offset_seconds: i32) {
+        match self {
+            Self::DateTime(dt) => {
+                *dt = dt.reinterpret_naive_as_local(offset_seconds);
+            }
+            Self::Until(inner) | Self::Negate(inner) | Self::Group(inner) => {
+                inner.apply_local_offset(offset_seconds);
+            }
+            Self::Binary { left, right, .. }
+            | Self::Power {
+                base: left,
+                exponent: right,
+            }
+            | Self::Equality { left, right }
+            | Self::Comparison { left, right, .. } => {
+                left.apply_local_offset(offset_seconds);
+                right.apply_local_offset(offset_seconds);
+            }
+            Self::AtTime { value, time } => {
+                value.apply_local_offset(offset_seconds);
+                time.apply_local_offset(offset_seconds);
+            }
+            Self::FunctionCall { args, .. } => {
+                for arg in args {
+                    arg.apply_local_offset(offset_seconds);
+                }
+            }
+            Self::IndefiniteIntegral { integrand, .. } => {
+                integrand.apply_local_offset(offset_seconds);
+            }
+            Self::UnitConversion { value, .. } => value.apply_local_offset(offset_seconds),
+            Self::Number { .. } | Self::Now | Self::Variable(_) => {}
+        }
+    }
+
     /// Internal helper for to_lino.
     /// `parent_op` is the parent operator's precedence (if any) to determine
     /// if we need parentheses for this subexpression.

--- a/src/types/value/mod.rs
+++ b/src/types/value/mod.rs
@@ -402,8 +402,9 @@ impl Value {
                 self.subtract_rationals(a_rat, b.clone(), other, currency_db, date)
             }
             (ValueKind::DateTime(dt1), ValueKind::DateTime(dt2)) => {
-                let diff = dt1.subtract(dt2);
-                Ok(Value::duration(diff.as_secs() as i64))
+                // Signed difference (dt1 - dt2): a negative result (dt1 earlier
+                // than dt2) is preserved instead of collapsing to zero.
+                Ok(Value::duration(dt1.signed_subtract_seconds(dt2)))
             }
             (ValueKind::DateTime(dt), ValueKind::Duration { seconds }) => {
                 Ok(Value::datetime(dt.add_duration(-seconds)))

--- a/tests/issue_185_local_timezone_tests.rs
+++ b/tests/issue_185_local_timezone_tests.rs
@@ -46,7 +46,11 @@ fn explicit_utc_is_still_honored() {
     calc.set_timezone_offset(IST_MINUTES);
 
     let result = calc.calculate_internal("12:30 UTC");
-    assert!(result.success, "12:30 UTC should succeed: {:?}", result.error);
+    assert!(
+        result.success,
+        "12:30 UTC should succeed: {:?}",
+        result.error
+    );
     assert!(
         result.result.contains("UTC"),
         "explicit UTC must remain UTC regardless of the local offset: {}",
@@ -94,7 +98,11 @@ fn time_difference_uses_wall_clock_in_local_timezone() {
     // result is the wall-clock difference: 14:44 - 12:30 = 2h 14m.
     // Spaced form exercises the dedicated datetime-subtraction grammar path.
     let result = calc.calculate_internal("(14:44) - (12:30)");
-    assert!(result.success, "subtraction should succeed: {:?}", result.error);
+    assert!(
+        result.success,
+        "subtraction should succeed: {:?}",
+        result.error
+    );
     assert!(
         result.result.contains("2 hours") && result.result.contains("14 minutes"),
         "expected 2 hours, 14 minutes, got: {}",
@@ -109,7 +117,11 @@ fn unspaced_time_difference_uses_wall_clock() {
 
     // Unspaced form goes through the general expression evaluator (Binary op).
     let result = calc.calculate_internal("14:44-12:30");
-    assert!(result.success, "subtraction should succeed: {:?}", result.error);
+    assert!(
+        result.success,
+        "subtraction should succeed: {:?}",
+        result.error
+    );
     assert!(
         result.result.contains("2 hours") && result.result.contains("14 minutes"),
         "expected 2 hours, 14 minutes, got: {}",
@@ -123,7 +135,11 @@ fn negative_time_difference_is_not_collapsed_to_zero() {
     // an earlier-minus-later subtraction must yield a negative duration.
     let mut calc = Calculator::new();
     let result = calc.calculate_internal("12:00-14:00");
-    assert!(result.success, "subtraction should succeed: {:?}", result.error);
+    assert!(
+        result.success,
+        "subtraction should succeed: {:?}",
+        result.error
+    );
     assert!(
         !result.result.contains("0 seconds"),
         "negative difference must not collapse to 0 seconds: {}",
@@ -144,7 +160,11 @@ fn issue_185_now_minus_time_succeeds() {
     calc.set_timezone_offset(IST_MINUTES);
 
     let result = calc.calculate_internal("now-12:30");
-    assert!(result.success, "now-12:30 should succeed: {:?}", result.error);
+    assert!(
+        result.success,
+        "now-12:30 should succeed: {:?}",
+        result.error
+    );
     assert!(
         result.result.contains("second")
             || result.result.contains("minute")

--- a/tests/issue_185_local_timezone_tests.rs
+++ b/tests/issue_185_local_timezone_tests.rs
@@ -1,0 +1,170 @@
+//! Tests for issue #185: `now` and bare times should be interpreted in the
+//! user's local timezone (when known) instead of always defaulting to UTC.
+//!
+//! The user reported that `now-12:30` produced `0 seconds`. Two bugs were
+//! involved:
+//!   1. `now` and the bare time `12:30` were both treated as UTC, so the
+//!      calculation never matched the user's local wall clock.
+//!   2. `DateTime - DateTime` collapsed any negative difference to `0 seconds`
+//!      because it went through `std::time::Duration` (which cannot be negative).
+//!
+//! See <https://github.com/link-assistant/calculator/issues/185>.
+
+use link_calculator::Calculator;
+
+/// India Standard Time, UTC+5:30, in minutes east of UTC.
+const IST_MINUTES: i32 = 330;
+
+#[test]
+fn bare_time_uses_local_timezone_when_set() {
+    let mut calc = Calculator::new();
+    calc.set_timezone_offset(IST_MINUTES);
+
+    let result = calc.calculate_internal("12:30");
+    assert!(result.success, "12:30 should succeed: {:?}", result.error);
+    // The wall-clock reading is preserved, but now displayed in local time.
+    assert!(
+        result.result.contains("12:30:00"),
+        "expected wall clock 12:30:00, got: {}",
+        result.result
+    );
+    assert!(
+        result.result.contains("+05:30"),
+        "bare time should display the local offset, got: {}",
+        result.result
+    );
+    assert!(
+        !result.result.contains("UTC"),
+        "bare time must NOT be labelled UTC when a local offset is set: {}",
+        result.result
+    );
+}
+
+#[test]
+fn explicit_utc_is_still_honored() {
+    let mut calc = Calculator::new();
+    calc.set_timezone_offset(IST_MINUTES);
+
+    let result = calc.calculate_internal("12:30 UTC");
+    assert!(result.success, "12:30 UTC should succeed: {:?}", result.error);
+    assert!(
+        result.result.contains("UTC"),
+        "explicit UTC must remain UTC regardless of the local offset: {}",
+        result.result
+    );
+}
+
+#[test]
+fn now_uses_local_timezone_when_set() {
+    let mut calc = Calculator::new();
+    calc.set_timezone_offset(IST_MINUTES);
+
+    let result = calc.calculate_internal("now");
+    assert!(result.success, "now should succeed: {:?}", result.error);
+    assert!(
+        result.result.contains("current local time"),
+        "now should be labelled as local time: {}",
+        result.result
+    );
+    assert!(
+        result.result.contains("+05:30"),
+        "now should display the local offset: {}",
+        result.result
+    );
+}
+
+#[test]
+fn now_defaults_to_utc_without_offset() {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("now");
+    assert!(result.success);
+    assert!(
+        result.result.contains("current UTC time"),
+        "without a configured offset, now stays UTC: {}",
+        result.result
+    );
+}
+
+#[test]
+fn time_difference_uses_wall_clock_in_local_timezone() {
+    let mut calc = Calculator::new();
+    calc.set_timezone_offset(IST_MINUTES);
+
+    // Both operands are bare times re-anchored to the same local timezone, so the
+    // result is the wall-clock difference: 14:44 - 12:30 = 2h 14m.
+    // Spaced form exercises the dedicated datetime-subtraction grammar path.
+    let result = calc.calculate_internal("(14:44) - (12:30)");
+    assert!(result.success, "subtraction should succeed: {:?}", result.error);
+    assert!(
+        result.result.contains("2 hours") && result.result.contains("14 minutes"),
+        "expected 2 hours, 14 minutes, got: {}",
+        result.result
+    );
+}
+
+#[test]
+fn unspaced_time_difference_uses_wall_clock() {
+    let mut calc = Calculator::new();
+    calc.set_timezone_offset(IST_MINUTES);
+
+    // Unspaced form goes through the general expression evaluator (Binary op).
+    let result = calc.calculate_internal("14:44-12:30");
+    assert!(result.success, "subtraction should succeed: {:?}", result.error);
+    assert!(
+        result.result.contains("2 hours") && result.result.contains("14 minutes"),
+        "expected 2 hours, 14 minutes, got: {}",
+        result.result
+    );
+}
+
+#[test]
+fn negative_time_difference_is_not_collapsed_to_zero() {
+    // Reproduces the core of the reported "0 seconds" bug without timezones:
+    // an earlier-minus-later subtraction must yield a negative duration.
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("12:00-14:00");
+    assert!(result.success, "subtraction should succeed: {:?}", result.error);
+    assert!(
+        !result.result.contains("0 seconds"),
+        "negative difference must not collapse to 0 seconds: {}",
+        result.result
+    );
+    assert!(
+        result.result.contains("2 hours") && result.result.trim_start().starts_with('-'),
+        "expected a negative 2 hours, got: {}",
+        result.result
+    );
+}
+
+#[test]
+fn issue_185_now_minus_time_succeeds() {
+    // The exact expression from the issue. With a local offset configured it must
+    // succeed and produce a duration rather than the bogus "0 seconds".
+    let mut calc = Calculator::new();
+    calc.set_timezone_offset(IST_MINUTES);
+
+    let result = calc.calculate_internal("now-12:30");
+    assert!(result.success, "now-12:30 should succeed: {:?}", result.error);
+    assert!(
+        result.result.contains("second")
+            || result.result.contains("minute")
+            || result.result.contains("hour"),
+        "now-12:30 should produce a duration: {}",
+        result.result
+    );
+}
+
+#[test]
+fn clear_timezone_offset_restores_utc() {
+    let mut calc = Calculator::new();
+    calc.set_timezone_offset(IST_MINUTES);
+    calc.clear_timezone_offset();
+
+    let result = calc.calculate_internal("12:30");
+    assert!(result.success);
+    assert!(
+        result.result.contains("UTC"),
+        "after clearing the offset, bare times revert to UTC: {}",
+        result.result
+    );
+}

--- a/web/src/worker.ts
+++ b/web/src/worker.ts
@@ -24,6 +24,8 @@ interface CalculatorInstance {
   update_crypto_rates_from_api(base: string, date: string, rates_json: string): number;
   update_cbr_rates_from_api(date: string, rates_json: string): number;
   load_rates_from_consolidated_lino(content: string): number;
+  set_timezone_offset(offset_minutes: number): void;
+  clear_timezone_offset(): void;
 }
 
 interface CalculatorStatic {
@@ -74,6 +76,17 @@ async function initWasm() {
     await init();
     const CalcClass = Calculator as unknown as CalculatorStatic;
     calculator = new CalcClass();
+
+    // Issue #185: interpret `now` and timezone-less times in the user's local
+    // timezone by default, so `now-12:30` matches the user's wall clock.
+    // `Date.prototype.getTimezoneOffset()` returns minutes *behind* UTC (e.g.
+    // -330 for UTC+5:30), so negate it to get minutes *east* of UTC.
+    try {
+      calculator.set_timezone_offset(-new Date().getTimezoneOffset());
+    } catch (tzError) {
+      console.warn('Failed to set local timezone offset:', tzError);
+    }
+
     const version = CalcClass.version();
     self.postMessage({ type: 'ready', data: { version } });
 


### PR DESCRIPTION
## Summary

Fixes #185. The expression `now-12:30` returned **`0 seconds`** instead of the
expected wall-clock difference. Two independent bugs were responsible:

1. **Negative durations collapsed to zero.** `DateTime - DateTime` computed the
   difference via `std::time::Duration` (`subtract().as_secs()`), which cannot
   represent a negative value. When `now` (09:14 UTC in the report) was earlier
   than `12:30`, the result silently became `0 seconds`.

2. **`now` and bare times were always UTC.** The reporter's local time was
   14:44 (UTC+5:30). Both `now` and the timezone-less `12:30` were interpreted as
   UTC, so the calculation never matched their wall clock.

Per the issue: *"by default i expect to get 14:44-12:30, when using now or time
without UTC … And only if we specify UTC in the input it should be used in
calculations."*

## What changed

- **Signed subtraction** (`DateTime - DateTime`): both evaluation paths (the
  general AST evaluator in `value/mod.rs` and the dedicated
  `datetime_grammar` subtraction path) now use `signed_subtract_seconds`, so
  negative differences are preserved.
- **Local-timezone interpretation**: when a local timezone offset is configured,
  `now` and timezone-less times (e.g. `12:30`) are anchored to that timezone in
  **all** evaluation paths (`now`, `until`, standalone datetime, binary
  subtraction, and the spaced/parenthesized subtraction grammar). Inputs with an
  explicit timezone (`12:30 UTC`, `now UTC`) are always honored as written.
- **New API**: `Calculator::set_timezone_offset(offset_minutes)` and
  `clear_timezone_offset()` (exported to WASM).
- **Web wiring**: `web/src/worker.ts` calls `set_timezone_offset(-new Date().getTimezoneOffset())`
  on init, so the browser app uses the user's actual timezone. Default
  library/CLI behavior is unchanged (UTC) when no offset is set.

## How to reproduce

1. Open the calculator and enter `now-12:30` while your local time is past 12:30.
   - **Before:** `0 seconds` (when now < 12:30 UTC).
   - **After:** the correct signed wall-clock difference in local time.

## Tests

New regression suite `tests/issue_185_local_timezone_tests.rs` covers:

- bare `12:30` displays in the local offset (`+05:30`), not UTC;
- `12:30 UTC` stays UTC regardless of the configured offset;
- `now` shows "current local time" with the local offset; defaults to
  "current UTC time" with no offset;
- `(14:44) - (12:30)` and `14:44-12:30` both yield `2 hours, 14 minutes`
  (spaced grammar path and unspaced AST path);
- `12:00-14:00` yields a **negative** `2 hours` instead of `0 seconds`
  (the core regression);
- `now-12:30` succeeds and returns a duration;
- `clear_timezone_offset()` restores UTC.

All existing tests pass (`cargo test`: 0 failures), `cargo clippy` is clean, and
the web suite passes (`npm test`: 229 passed, `tsc --noEmit` clean).

A `changelog.d` fragment is included (`bump: minor`).
