### PR TITLE
fix: divide compatible duration units (#187)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-17T16:24:52.158Z for PR creation at branch issue-185-5c2838a97727 for issue https://github.com/link-assistant/calculator/issues/185
+# Updated: 2026-06-20T14:26:52.705Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-17T16:24:52.158Z for PR creation at branch issue-185-5c2838a97727 for issue https://github.com/link-assistant/calculator/issues/185
-# Updated: 2026-06-20T14:26:52.705Z

--- a/changelog.d/20260620_143139_duration_division.md
+++ b/changelog.d/20260620_143139_duration_division.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- Fixed duration division so compatible time units produce a unitless ratio, such as `8 hours / 30 minutes = 16`.

--- a/src/types/value/duration.rs
+++ b/src/types/value/duration.rs
@@ -1,3 +1,7 @@
+use super::Value;
+use crate::error::CalculatorError;
+use crate::types::{DateTime, DurationUnit, Rational, Unit};
+
 /// Formats a duration in seconds to a human-readable string.
 pub(super) fn format_duration(total_seconds: i64) -> String {
     let is_negative = total_seconds < 0;
@@ -40,5 +44,66 @@ pub(super) fn format_duration(total_seconds: i64) -> String {
         format!("-{result}")
     } else {
         result
+    }
+}
+
+/// Divides compatible duration-unit values as a unitless ratio.
+pub(super) fn divide_duration_units(
+    left: &Value,
+    right: &Value,
+) -> Result<Option<Value>, CalculatorError> {
+    let (Unit::Duration(left_unit), Unit::Duration(right_unit)) = (&left.unit, &right.unit) else {
+        return Ok(None);
+    };
+
+    let left_amount = left.to_rational().ok_or_else(|| {
+        CalculatorError::InvalidOperation("duration division requires numeric values".into())
+    })?;
+    let right_amount = right.to_rational().ok_or_else(|| {
+        CalculatorError::InvalidOperation("duration division requires numeric values".into())
+    })?;
+
+    let left_seconds = left_amount * duration_unit_seconds(*left_unit);
+    let right_seconds = right_amount * duration_unit_seconds(*right_unit);
+    if right_seconds.is_zero() {
+        return Err(CalculatorError::DivisionByZero);
+    }
+
+    Ok(Some(Value::rational(left_seconds / right_seconds)))
+}
+
+/// Applies a signed duration to a `DateTime`, using calendar arithmetic for
+/// months and years and second-based arithmetic for all other units.
+///
+/// `amount` is positive for addition and negative for subtraction.
+pub(super) fn add_calendar_months_or_duration(
+    dt: &DateTime,
+    unit: DurationUnit,
+    amount: f64,
+) -> DateTime {
+    match unit {
+        DurationUnit::Months => dt.add_calendar_months(amount as i32),
+        DurationUnit::Years => dt.add_calendar_months((amount * 12.0) as i32),
+        other => {
+            let seconds = other.to_secs(amount.abs()) as i64;
+            if amount >= 0.0 {
+                dt.add_duration(seconds)
+            } else {
+                dt.add_duration(-seconds)
+            }
+        }
+    }
+}
+
+fn duration_unit_seconds(unit: DurationUnit) -> Rational {
+    match unit {
+        DurationUnit::Milliseconds => Rational::new(1, 1000),
+        DurationUnit::Seconds => Rational::one(),
+        DurationUnit::Minutes => Rational::from_integer(60),
+        DurationUnit::Hours => Rational::from_integer(3600),
+        DurationUnit::Days => Rational::from_integer(86_400),
+        DurationUnit::Weeks => Rational::from_integer(604_800),
+        DurationUnit::Months => Rational::from_integer(2_592_000),
+        DurationUnit::Years => Rational::from_integer(31_536_000),
     }
 }

--- a/src/types/value/mod.rs
+++ b/src/types/value/mod.rs
@@ -2,14 +2,14 @@
 
 mod duration;
 mod kind;
-use duration::format_duration;
+use duration::{add_calendar_months_or_duration, divide_duration_units, format_duration};
 pub use kind::ValueKind;
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
 use crate::error::CalculatorError;
-use crate::types::{CurrencyDatabase, DateTime, Decimal, DurationUnit, Rational, Unit};
+use crate::types::{CurrencyDatabase, DateTime, Decimal, Rational, Unit};
 
 /// A typed value with an optional unit.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -599,6 +599,9 @@ impl Value {
                 if b.is_zero() {
                     return Err(CalculatorError::DivisionByZero);
                 }
+                if let Some(result) = divide_duration_units(self, other)? {
+                    return Ok(result);
+                }
                 let result = a.clone() / b.clone();
 
                 // Handle unit division
@@ -616,6 +619,9 @@ impl Value {
             (ValueKind::Number(a), ValueKind::Number(b)) => {
                 if b.is_zero() {
                     return Err(CalculatorError::DivisionByZero);
+                }
+                if let Some(result) = divide_duration_units(self, other)? {
+                    return Ok(result);
                 }
                 let result = a.checked_div(b).ok_or(CalculatorError::Overflow)?;
 
@@ -635,6 +641,9 @@ impl Value {
                 if b.is_zero() {
                     return Err(CalculatorError::DivisionByZero);
                 }
+                if let Some(result) = divide_duration_units(self, other)? {
+                    return Ok(result);
+                }
                 let b_rat = Rational::from_decimal(*b);
                 let result = a.clone() / b_rat;
 
@@ -651,6 +660,9 @@ impl Value {
             (ValueKind::Number(a), ValueKind::Rational(b)) => {
                 if b.is_zero() {
                     return Err(CalculatorError::DivisionByZero);
+                }
+                if let Some(result) = divide_duration_units(self, other)? {
+                    return Ok(result);
                 }
                 let a_rat = Rational::from_decimal(*a);
                 let result = a_rat / b.clone();
@@ -970,25 +982,6 @@ impl PartialEq for Value {
                 (a.to_f64() - b.to_f64()).abs() < 1e-10 && self.unit == other.unit
             }
             _ => self.kind == other.kind && self.unit == other.unit,
-        }
-    }
-}
-
-/// Applies a signed duration to a `DateTime`, using calendar arithmetic for
-/// months and years and second-based arithmetic for all other units.
-///
-/// `amount` is positive for addition and negative for subtraction.
-fn add_calendar_months_or_duration(dt: &DateTime, unit: DurationUnit, amount: f64) -> DateTime {
-    match unit {
-        DurationUnit::Months => dt.add_calendar_months(amount as i32),
-        DurationUnit::Years => dt.add_calendar_months((amount * 12.0) as i32),
-        other => {
-            let seconds = other.to_secs(amount.abs()) as i64;
-            if amount >= 0.0 {
-                dt.add_duration(seconds)
-            } else {
-                dt.add_duration(-seconds)
-            }
         }
     }
 }

--- a/tests/issue_187_duration_division_tests.rs
+++ b/tests/issue_187_duration_division_tests.rs
@@ -1,0 +1,36 @@
+//! Regression tests for issue #187: dividing compatible duration units.
+//!
+//! The original report showed `8 часов / 30 минут` evaluating to
+//! `0.2666666666666667 hours`, because the raw numbers were divided and the
+//! left-hand duration unit was preserved. Duration divided by duration should
+//! be a unitless ratio after converting both sides to the same base unit.
+
+use link_calculator::Calculator;
+
+#[test]
+fn issue_187_russian_hours_divided_by_minutes_is_unitless_ratio() {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("8 часов / 30 минут");
+
+    assert!(result.success, "calculation failed: {:?}", result.error);
+    assert_eq!(result.result, "16");
+    assert_eq!(result.lino_interpretation, "((8 hours) / (30 minutes))");
+}
+
+#[test]
+fn issue_187_english_hours_divided_by_minutes_is_unitless_ratio() {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("8 hours / 30 minutes");
+
+    assert!(result.success, "calculation failed: {:?}", result.error);
+    assert_eq!(result.result, "16");
+}
+
+#[test]
+fn issue_187_reverse_duration_division_converts_units() {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("30 minutes / 8 hours");
+
+    assert!(result.success, "calculation failed: {:?}", result.error);
+    assert_eq!(result.result, "0.0625");
+}


### PR DESCRIPTION
## Summary
- Convert duration-unit operands to exact seconds before division.
- Return duration divided by duration as a unitless ratio.
- Add regression coverage for the reported Russian expression and reverse-unit division.

## Reproduction
Before this change, `8 часов / 30 минут` returned `0.2666666666666667 hours`. It now returns `16`.

## Tests
- `cargo test --test issue_187_duration_division_tests`
- `cargo test`
- `cargo clippy --all-targets --all-features`
- `cargo fmt --check`
- `node scripts/check-file-size.mjs`
- `node scripts/check-changelog-fragment.mjs`

Fixes #187