### PR TITLE
fix: show denominator grouping for division/product chains

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-17T16:24:52.158Z for PR creation at branch issue-185-5c2838a97727 for issue https://github.com/link-assistant/calculator/issues/185
+# Updated: 2026-06-20T14:28:55.129Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-06-17T16:24:52.158Z for PR creation at branch issue-185-5c2838a97727 for issue https://github.com/link-assistant/calculator/issues/185
-# Updated: 2026-06-20T14:28:55.129Z

--- a/changelog.d/20260620_143000_issue_188_interpretation_options.md
+++ b/changelog.d/20260620_143000_issue_188_interpretation_options.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+
+### Fixed
+- Show the grouped-denominator interpretation for chained division and multiplication such as `253 / 16 * 3`.

--- a/src/types/expression.rs
+++ b/src/types/expression.rs
@@ -450,7 +450,9 @@ impl Expression {
     ///
     /// Ambiguity arises from:
     /// - Binary operations where precedence changes meaning (e.g., `2 + 3 * 4`)
-    /// - Function calls that could also be read as other structures
+    /// - Division/product chains where users may intend a grouped denominator
+    ///   (e.g., `253 / 16 * 3` vs `253 / (16 * 3)`)
+    /// - Function call arguments that contain their own alternatives
     #[must_use]
     pub fn alternative_lino(&self) -> Option<Vec<String>> {
         let default_lino = self.to_lino();
@@ -495,18 +497,9 @@ impl Expression {
                     alternatives.push(alt);
                 }
             }
-            // For expressions with mixed precedence, show the explicit grouping
-            Self::Binary { left, op, right } => {
-                // Check if either child has a different-precedence binary operation
-                // e.g., in `2 + 3 * 4`, show both `(2 + (3 * 4))` and `((2 + 3) * 4)`
-                let has_different_precedence_child =
-                    Self::has_different_precedence_child(left, *op)
-                        || Self::has_different_precedence_child(right, *op);
-
-                if has_different_precedence_child {
-                    // Alternative: re-group with opposite precedence assumption
-                    // left-to-right grouping
-                    let alt = self.to_lino_left_to_right();
+            // For expressions with alternative groupings, show the explicit grouping
+            Self::Binary { left, right, .. } => {
+                if let Some(alt) = self.to_lino_alternative_grouping() {
                     alternatives.push(alt);
                 }
 
@@ -528,34 +521,42 @@ impl Expression {
         }
     }
 
-    /// Checks if a child expression has a binary op with different precedence.
-    fn has_different_precedence_child(child: &Expression, parent_op: BinaryOp) -> bool {
-        if let Self::Binary { op, .. } = child {
-            return op.precedence() != parent_op.precedence();
-        }
-        false
+    fn can_regroup_right_child(parent_op: BinaryOp, child_op: BinaryOp) -> bool {
+        child_op.precedence() != parent_op.precedence()
+            || matches!(
+                (parent_op, child_op),
+                (BinaryOp::Divide, BinaryOp::Multiply)
+            )
     }
 
-    /// Generates a left-to-right grouped lino notation (alternative grouping).
-    fn to_lino_left_to_right(&self) -> String {
+    fn can_regroup_left_child(child_op: BinaryOp, parent_op: BinaryOp) -> bool {
+        child_op.precedence() != parent_op.precedence()
+            || matches!(
+                (child_op, parent_op),
+                (BinaryOp::Divide, BinaryOp::Multiply)
+            )
+    }
+
+    /// Generates one alternative grouped lino notation, if this binary node has one.
+    fn to_lino_alternative_grouping(&self) -> Option<String> {
         match self {
             Self::Binary { left, op, right } => {
                 // In left-to-right: ((left op1 right_left) op2 right_right)
                 // or: (left_left op1 (left_right op2 right))
-                // depending on where the different-precedence child is
+                // depending on where the regroupable child is.
                 if let Self::Binary {
                     left: rl,
                     op: rop,
                     right: rr,
                 } = right.as_ref()
                 {
-                    if rop.precedence() != op.precedence() {
+                    if Self::can_regroup_right_child(*op, *rop) {
                         // Default: left op (rl rop rr) => already `(left op (rl rop rr))`
                         // Alternative: (left op rl) rop rr => `((left op rl) rop rr)`
                         let new_left =
                             Self::binary(left.as_ref().clone(), *op, rl.as_ref().clone());
                         let new_expr = Self::binary(new_left, *rop, rr.as_ref().clone());
-                        return new_expr.to_lino();
+                        return Some(new_expr.to_lino());
                     }
                 }
                 if let Self::Binary {
@@ -564,18 +565,18 @@ impl Expression {
                     right: lr,
                 } = left.as_ref()
                 {
-                    if lop.precedence() != op.precedence() {
+                    if Self::can_regroup_left_child(*lop, *op) {
                         // Default: (ll lop lr) op right => already `((ll lop lr) op right)`
                         // Alternative: ll lop (lr op right) => `(ll lop (lr op right))`
                         let new_right =
                             Self::binary(lr.as_ref().clone(), *op, right.as_ref().clone());
                         let new_expr = Self::binary(ll.as_ref().clone(), *lop, new_right);
-                        return new_expr.to_lino();
+                        return Some(new_expr.to_lino());
                     }
                 }
-                self.to_lino()
+                None
             }
-            _ => self.to_lino(),
+            _ => None,
         }
     }
 

--- a/tests/issue_188_interpretation_options_tests.rs
+++ b/tests/issue_188_interpretation_options_tests.rs
@@ -1,0 +1,31 @@
+//! Regression tests for issue #188.
+//!
+//! Chained division and multiplication should expose both natural grouping
+//! interpretations so the user can choose the intended denominator.
+
+use link_calculator::Calculator;
+
+#[test]
+fn division_then_multiplication_exposes_denominator_grouping_alternative() {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("253 / 16 * 3");
+
+    assert!(result.success, "calculation failed: {:?}", result.error);
+    assert_eq!(result.result, "47.4375");
+    assert_eq!(result.lino_interpretation, "((253 / 16) * 3)");
+
+    let alternatives = result.alternative_lino.expect("missing alternatives");
+    assert_eq!(alternatives, vec!["((253 / 16) * 3)", "(253 / (16 * 3))"]);
+}
+
+#[test]
+fn plan_includes_division_multiplication_interpretations() {
+    let calc = Calculator::new();
+    let plan = calc.plan_internal("253 / 16 * 3");
+
+    assert!(plan.success, "plan failed: {:?}", plan.error);
+    assert_eq!(plan.lino_interpretation, "((253 / 16) * 3)");
+
+    let alternatives = plan.alternative_lino.expect("missing alternatives");
+    assert_eq!(alternatives, vec!["((253 / 16) * 3)", "(253 / (16 * 3))"]);
+}


### PR DESCRIPTION
## Summary

Fixes #188 by adding the missing alternative LINO interpretation for chained division and multiplication where the user may intend the trailing product to be part of the denominator.

For `253 / 16 * 3`, the calculator now exposes:

```text
((253 / 16) * 3)
(253 / (16 * 3))
```

## Root Cause

`Expression::alternative_lino()` only generated regrouping alternatives when a binary child had different operator precedence from its parent. `253 / 16 * 3` parses as a same-precedence left-associated tree, so the alternative generator returned no alternatives.

## Reproduction

Before this change, calculating `253 / 16 * 3` returned only:

```text
((253 / 16) * 3)
```

## Tests

- `cargo test --test issue_188_interpretation_options_tests -- --nocapture`
- `cargo test alternative_interpretation_tests -- --nocapture`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features`
- `node scripts/check-file-size.mjs`
- `cargo test`

## Notes

This is not a visual UI change, so no screenshot is included.
