### PR TITLE
fix: treat date differences as day counts (#191)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-25T17:58:29.528Z for PR creation at branch issue-191-1810bb08a1c2 for issue https://github.com/link-assistant/calculator/issues/191

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-25T17:58:29.528Z for PR creation at branch issue-191-1810bb08a1c2 for issue https://github.com/link-assistant/calculator/issues/191

--- a/changelog.d/20260625_180612_duration_day_count.md
+++ b/changelog.d/20260625_180612_duration_day_count.md
@@ -1,0 +1,2 @@
+### Fixed
+- Treat raw date-difference durations as day-count numbers when divided by scalars, and allow explicit conversion to duration units or unitless numbers.

--- a/src/grammar/expression_parser.rs
+++ b/src/grammar/expression_parser.rs
@@ -549,7 +549,7 @@ impl ExpressionParser {
                 steps.push(format!(
                     "Convert: {} to {}",
                     val.to_display_string(),
-                    target_unit.display_name()
+                    target_unit.conversion_target_name()
                 ));
 
                 // Clear any previous rate tracking before the conversion

--- a/src/grammar/token_parser/units.rs
+++ b/src/grammar/token_parser/units.rs
@@ -16,6 +16,10 @@ impl TokenParser<'_> {
         let unit_str = id.clone();
         self.advance();
 
+        if is_number_conversion_target(&unit_str) {
+            return Ok(Unit::None);
+        }
+
         if let Some(data_size) = DataSizeUnit::parse(&unit_str) {
             return Ok(Unit::DataSize(data_size));
         }
@@ -52,7 +56,8 @@ impl TokenParser<'_> {
              currencies (USD, EUR, GBP, TON, BTC, ETH, ...) and natural language \
              aliases (dollars, euros, bitcoin, toncoin, ...), \
              timezones (UTC, GMT, EST, MSK, JST, ...), \
-             time durations (ms, seconds, minutes, hours, days, weeks, months, years)."
+             time durations (ms, seconds, minutes, hours, days, weeks, months, years), \
+             and number/unitless."
         )))
     }
 
@@ -89,4 +94,24 @@ impl TokenParser<'_> {
         }
         expr
     }
+}
+
+fn is_number_conversion_target(unit_str: &str) -> bool {
+    matches!(
+        unit_str.to_lowercase().as_str(),
+        "number"
+            | "numbers"
+            | "unitless"
+            | "scalar"
+            | "число"
+            | "числа"
+            | "числом"
+            | "zahl"
+            | "nombre"
+            | "数字"
+            | "数"
+            | "संख्या"
+            | "رقم"
+            | "عدد"
+    )
 }

--- a/src/types/expression.rs
+++ b/src/types/expression.rs
@@ -424,7 +424,8 @@ impl Expression {
             }
             Self::UnitConversion { value, target_unit } => {
                 let value_str = value.to_lino_internal(None);
-                format!("({value_str} as {target_unit})")
+                let target = target_unit.conversion_target_name();
+                format!("({value_str} as {target})")
             }
             Self::Equality { left, right } => {
                 let left_str = left.to_lino_internal(None);
@@ -852,7 +853,8 @@ impl Expression {
                 format!("\\int {} \\, d{}", integrand.to_latex(), variable)
             }
             Self::UnitConversion { value, target_unit } => {
-                format!("{} \\to \\text{{{target_unit}}}", value.to_latex())
+                let target = target_unit.conversion_target_name();
+                format!("{} \\to \\text{{{target}}}", value.to_latex())
             }
             Self::Equality { left, right } => {
                 format!("{} = {}", left.to_latex(), right.to_latex())
@@ -916,7 +918,8 @@ impl fmt::Display for Expression {
                 write!(f, "integrate {integrand} d{variable}")
             }
             Self::UnitConversion { value, target_unit } => {
-                write!(f, "{value} as {target_unit}")
+                let target = target_unit.conversion_target_name();
+                write!(f, "{value} as {target}")
             }
             Self::Equality { left, right } => write!(f, "{left} = {right}"),
             Self::Comparison { left, op, right } => {

--- a/src/types/unit.rs
+++ b/src/types/unit.rs
@@ -507,6 +507,15 @@ impl Unit {
             Self::Custom(name) => name.clone(),
         }
     }
+
+    /// Returns the display name for a unit conversion target.
+    #[must_use]
+    pub fn conversion_target_name(&self) -> String {
+        match self {
+            Self::None => "number".to_string(),
+            _ => self.display_name(),
+        }
+    }
 }
 
 impl fmt::Display for Unit {

--- a/src/types/value/duration.rs
+++ b/src/types/value/duration.rs
@@ -72,6 +72,75 @@ pub(super) fn divide_duration_units(
     Ok(Some(Value::rational(left_seconds / right_seconds)))
 }
 
+/// Converts a raw duration in seconds into a numeric amount in `unit`.
+pub(super) fn duration_seconds_to_unit(seconds: i64, unit: DurationUnit) -> Rational {
+    Rational::from_integer(i128::from(seconds)) / duration_unit_seconds(unit)
+}
+
+/// Converts a raw duration in seconds into its numeric day count.
+pub(super) fn duration_seconds_to_days(seconds: i64) -> Rational {
+    duration_seconds_to_unit(seconds, DurationUnit::Days)
+}
+
+pub(super) fn divide_raw_duration(seconds: i64, divisor: &Value) -> Result<Value, CalculatorError> {
+    let divisor_amount = divisor.to_rational().ok_or_else(|| {
+        CalculatorError::InvalidOperation("duration division requires a numeric divisor".into())
+    })?;
+    if divisor_amount.is_zero() {
+        return Err(CalculatorError::DivisionByZero);
+    }
+
+    match &divisor.unit {
+        Unit::None => Ok(Value::rational(
+            duration_seconds_to_days(seconds) / divisor_amount,
+        )),
+        Unit::Duration(unit) => {
+            let divisor_seconds = divisor_amount * duration_unit_seconds(*unit);
+            if divisor_seconds.is_zero() {
+                return Err(CalculatorError::DivisionByZero);
+            }
+            Ok(Value::rational(
+                Rational::from_integer(i128::from(seconds)) / divisor_seconds,
+            ))
+        }
+        unit => Err(CalculatorError::InvalidOperation(format!(
+            "Cannot divide duration by {}",
+            unit.display_name()
+        ))),
+    }
+}
+
+pub(super) fn convert_raw_duration(
+    seconds: i64,
+    target_unit: &Unit,
+) -> Result<Value, CalculatorError> {
+    match target_unit {
+        Unit::None => Ok(Value::rational(duration_seconds_to_days(seconds))),
+        Unit::Duration(unit) => Ok(Value::rational_with_unit(
+            duration_seconds_to_unit(seconds, *unit),
+            Unit::Duration(*unit),
+        )),
+        _ => Err(CalculatorError::InvalidOperation(format!(
+            "Cannot convert duration to {}",
+            target_unit.display_name()
+        ))),
+    }
+}
+
+pub(super) fn apply_duration_unit(
+    value: &Value,
+    unit: DurationUnit,
+) -> Result<Value, CalculatorError> {
+    value
+        .to_rational()
+        .map(|amount| Value::rational_with_unit(amount, Unit::Duration(unit)))
+        .ok_or_else(|| {
+            CalculatorError::InvalidOperation(
+                "duration unit conversion requires a numeric value".into(),
+            )
+        })
+}
+
 /// Applies a signed duration to a `DateTime`, using calendar arithmetic for
 /// months and years and second-based arithmetic for all other units.
 ///
@@ -95,7 +164,7 @@ pub(super) fn add_calendar_months_or_duration(
     }
 }
 
-fn duration_unit_seconds(unit: DurationUnit) -> Rational {
+pub(super) fn duration_unit_seconds(unit: DurationUnit) -> Rational {
     match unit {
         DurationUnit::Milliseconds => Rational::new(1, 1000),
         DurationUnit::Seconds => Rational::one(),

--- a/src/types/value/mod.rs
+++ b/src/types/value/mod.rs
@@ -2,7 +2,10 @@
 
 mod duration;
 mod kind;
-use duration::{add_calendar_months_or_duration, divide_duration_units, format_duration};
+use duration::{
+    add_calendar_months_or_duration, apply_duration_unit, convert_raw_duration,
+    divide_duration_units, divide_raw_duration, format_duration,
+};
 pub use kind::ValueKind;
 
 use serde::{Deserialize, Serialize};
@@ -677,19 +680,8 @@ impl Value {
 
                 Ok(Value::rational_with_unit(result, unit))
             }
-            (ValueKind::Duration { seconds }, ValueKind::Number(n)) => {
-                if n.is_zero() {
-                    return Err(CalculatorError::DivisionByZero);
-                }
-                let result_secs = (*seconds as f64) / n.to_f64();
-                Ok(Value::duration(result_secs as i64))
-            }
-            (ValueKind::Duration { seconds }, ValueKind::Rational(r)) => {
-                if r.is_zero() {
-                    return Err(CalculatorError::DivisionByZero);
-                }
-                let result_secs = (*seconds as f64) / r.to_f64();
-                Ok(Value::duration(result_secs as i64))
+            (ValueKind::Duration { seconds }, ValueKind::Number(_) | ValueKind::Rational(_)) => {
+                divide_raw_duration(*seconds, other)
             }
             _ => Err(CalculatorError::InvalidOperation(format!(
                 "Cannot divide {} by {}",
@@ -742,7 +734,19 @@ impl Value {
         currency_db: &mut CurrencyDatabase,
         date: Option<&DateTime>,
     ) -> Result<Self, CalculatorError> {
+        if let ValueKind::Duration { seconds } = &self.kind {
+            return convert_raw_duration(*seconds, target_unit);
+        }
+
         match (&self.unit, target_unit) {
+            (_, Unit::None) => {
+                let value = self.to_rational().ok_or_else(|| {
+                    CalculatorError::InvalidOperation(
+                        "number conversion requires a numeric value".into(),
+                    )
+                })?;
+                Ok(Value::rational(value))
+            }
             // Data size to data size conversion
             (Unit::DataSize(from), Unit::DataSize(to)) => {
                 let value_f64 = self.as_decimal().ok_or_else(|| {
@@ -815,6 +819,7 @@ impl Value {
                 })?;
                 Ok(Value::number_with_unit(value_f64, target_unit.clone()))
             }
+            (Unit::None, Unit::Duration(unit)) => apply_duration_unit(self, *unit),
             // DateTime timezone conversion (e.g., "6 PM GMT as MSK")
             (_, Unit::Timezone(tz_abbrev)) => {
                 if let ValueKind::DateTime(dt) = &self.kind {

--- a/tests/issue_191_duration_day_count_tests.rs
+++ b/tests/issue_191_duration_day_count_tests.rs
@@ -1,0 +1,56 @@
+//! Regression tests for issue #191.
+//!
+//! Date subtraction produces a raw duration. When that duration is used in
+//! scalar arithmetic, users expect its day count, so expressions like
+//! `(8 августа - 17 июня) / 30 * 3500` should evaluate as
+//! `52 / 30 * 3500` instead of failing as duration multiplication.
+
+use link_calculator::Calculator;
+
+#[test]
+fn issue_191_russian_date_difference_divided_by_number_multiplies_as_day_count() {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("(8 августа - 17 июня) / 30 * 3500");
+
+    assert!(result.success, "calculation failed: {:?}", result.error);
+    assert_eq!(result.result, "6066.66666666667");
+    assert_eq!(result.fraction.as_deref(), Some("18200/3"));
+}
+
+#[test]
+fn issue_191_day_count_arithmetic_preserves_currency_unit() {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("((8 августа - 17 июня) / 30 * 3500 рупий)");
+
+    assert!(result.success, "calculation failed: {:?}", result.error);
+    assert_eq!(result.result, "6066.66666666667 INR");
+    assert_eq!(result.fraction.as_deref(), Some("18200/3"));
+}
+
+#[test]
+fn issue_191_raw_duration_can_be_explicitly_converted_to_days() {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("(8 августа - 17 июня) as days");
+
+    assert!(result.success, "calculation failed: {:?}", result.error);
+    assert_eq!(result.result, "52 days");
+}
+
+#[test]
+fn issue_191_raw_duration_can_be_explicitly_converted_to_number() {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("(8 августа - 17 июня) as number");
+
+    assert!(result.success, "calculation failed: {:?}", result.error);
+    assert_eq!(result.result, "52");
+}
+
+#[test]
+fn issue_191_divided_duration_can_be_explicitly_labeled_as_days() {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("((8 августа - 17 июня) / 30) as days");
+
+    assert!(result.success, "calculation failed: {:?}", result.error);
+    assert_eq!(result.result, "1.733333333333333 days");
+    assert_eq!(result.fraction.as_deref(), Some("26/15"));
+}


### PR DESCRIPTION
## Summary
- Treat raw date-difference durations as day-count rationals when divided by unitless scalars.
- Preserve exact fractions and downstream units/currencies, including the INR case from the issue.
- Add explicit `as days` and `as number` conversions for raw date-difference durations.

## Reproduction
Before this change:
- `(8 августа - 17 июня) / 30 * 3500` failed with `Invalid operation: Cannot multiply duration and number`.
- `((8 августа - 17 июня) / 30 * 3500 рупий)` failed with the same duration/number error.
- `(8 августа - 17 июня) as number` parsed `number` as an unknown conversion unit.

After this change:
- `(8 августа - 17 июня) / 30 * 3500` returns `6066.66666666667` (`18200/3`).
- `((8 августа - 17 июня) / 30 * 3500 рупий)` returns `6066.66666666667 INR`.
- `(8 августа - 17 июня) as days` returns `52 days`.
- `(8 августа - 17 июня) as number` returns `52`.

## Tests
- `cargo fmt --check`
- `node scripts/check-file-size.mjs`
- `node scripts/check-changelog-fragment.mjs`
- `cargo clippy --all-targets --all-features`
- `cargo test`
- `cargo test --test issue_191_duration_day_count_tests`

Fixes #191
