### PR TITLE
fix: divide date durations by currency as counts (#193)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-25T18:54:07.302Z for PR creation at branch issue-193-2b86e2b9c679 for issue https://github.com/link-assistant/calculator/issues/193

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-25T18:54:07.302Z for PR creation at branch issue-193-2b86e2b9c679 for issue https://github.com/link-assistant/calculator/issues/193

--- a/changelog.d/20260625_185714_duration_currency_division.md
+++ b/changelog.d/20260625_185714_duration_currency_division.md
@@ -1,0 +1,2 @@
+### Fixed
+- Treat date-difference durations as numeric day/hour counts when dividing by currency expressions.

--- a/src/types/value/duration.rs
+++ b/src/types/value/duration.rs
@@ -103,6 +103,9 @@ pub(super) fn divide_raw_duration(seconds: i64, divisor: &Value) -> Result<Value
                 Rational::from_integer(i128::from(seconds)) / divisor_seconds,
             ))
         }
+        Unit::Currency(_) => Ok(Value::rational(
+            duration_seconds_to_days(seconds) / divisor_amount,
+        )),
         unit => Err(CalculatorError::InvalidOperation(format!(
             "Cannot divide duration by {}",
             unit.display_name()

--- a/src/types/value/mod.rs
+++ b/src/types/value/mod.rs
@@ -608,13 +608,7 @@ impl Value {
                 let result = a.clone() / b.clone();
 
                 // Handle unit division
-                let unit = match (&self.unit, &other.unit) {
-                    (Unit::Currency(c1), Unit::Currency(c2)) if c1 == c2 => Unit::None,
-                    (unit, Unit::None) => unit.clone(),
-                    (Unit::None, _) => Unit::None,
-                    (u1, u2) if u1 == u2 => Unit::None,
-                    _ => self.unit.clone(),
-                };
+                let unit = Self::division_result_unit(&self.unit, &other.unit);
 
                 Ok(Value::rational_with_unit(result, unit))
             }
@@ -629,13 +623,7 @@ impl Value {
                 let result = a.checked_div(b).ok_or(CalculatorError::Overflow)?;
 
                 // Handle unit division
-                let unit = match (&self.unit, &other.unit) {
-                    (Unit::Currency(c1), Unit::Currency(c2)) if c1 == c2 => Unit::None,
-                    (unit, Unit::None) => unit.clone(),
-                    (Unit::None, _) => Unit::None,
-                    (u1, u2) if u1 == u2 => Unit::None,
-                    _ => self.unit.clone(),
-                };
+                let unit = Self::division_result_unit(&self.unit, &other.unit);
 
                 Ok(Value::number_with_unit(result, unit))
             }
@@ -650,13 +638,7 @@ impl Value {
                 let b_rat = Rational::from_decimal(*b);
                 let result = a.clone() / b_rat;
 
-                let unit = match (&self.unit, &other.unit) {
-                    (Unit::Currency(c1), Unit::Currency(c2)) if c1 == c2 => Unit::None,
-                    (unit, Unit::None) => unit.clone(),
-                    (Unit::None, _) => Unit::None,
-                    (u1, u2) if u1 == u2 => Unit::None,
-                    _ => self.unit.clone(),
-                };
+                let unit = Self::division_result_unit(&self.unit, &other.unit);
 
                 Ok(Value::rational_with_unit(result, unit))
             }
@@ -670,13 +652,7 @@ impl Value {
                 let a_rat = Rational::from_decimal(*a);
                 let result = a_rat / b.clone();
 
-                let unit = match (&self.unit, &other.unit) {
-                    (Unit::Currency(c1), Unit::Currency(c2)) if c1 == c2 => Unit::None,
-                    (unit, Unit::None) => unit.clone(),
-                    (Unit::None, _) => Unit::None,
-                    (u1, u2) if u1 == u2 => Unit::None,
-                    _ => self.unit.clone(),
-                };
+                let unit = Self::division_result_unit(&self.unit, &other.unit);
 
                 Ok(Value::rational_with_unit(result, unit))
             }
@@ -688,6 +664,17 @@ impl Value {
                 self.type_name(),
                 other.type_name()
             ))),
+        }
+    }
+
+    fn division_result_unit(left: &Unit, right: &Unit) -> Unit {
+        match (left, right) {
+            (Unit::Currency(c1), Unit::Currency(c2)) if c1 == c2 => Unit::None,
+            (Unit::Duration(_), Unit::Currency(_)) => Unit::None,
+            (unit, Unit::None) => unit.clone(),
+            (Unit::None, _) => Unit::None,
+            (u1, u2) if u1 == u2 => Unit::None,
+            _ => left.clone(),
         }
     }
 

--- a/tests/issue_193_duration_currency_division_tests.rs
+++ b/tests/issue_193_duration_currency_division_tests.rs
@@ -1,0 +1,39 @@
+//! Regression tests for issue #193.
+//!
+//! A raw date difference should behave as a numeric day count when divided by
+//! a currency expression. Explicit duration-unit conversions, such as hours,
+//! should also divide by currency as their numeric unit count instead of
+//! preserving the duration unit in the result.
+
+use link_calculator::Calculator;
+
+#[test]
+fn issue_193_date_difference_divided_by_inr_product_uses_day_count() {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("(((2026-08-08) - (2026-06-17)) / (30 * (3500 INR)))");
+
+    assert!(result.success, "calculation failed: {:?}", result.error);
+    assert_eq!(result.result, "0.000495238095238095");
+    assert_eq!(result.fraction.as_deref(), Some("13/26250"));
+}
+
+#[test]
+fn issue_193_localized_currency_name_uses_same_duration_day_count_rule() {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("(((2026-08-08) - (2026-06-17)) / (30 * (3500 рупий)))");
+
+    assert!(result.success, "calculation failed: {:?}", result.error);
+    assert_eq!(result.result, "0.000495238095238095");
+    assert_eq!(result.fraction.as_deref(), Some("13/26250"));
+}
+
+#[test]
+fn issue_193_explicit_duration_unit_divided_by_currency_becomes_number() {
+    let mut calc = Calculator::new();
+    let result =
+        calc.calculate_internal("(((2026-08-08) - (2026-06-17)) as hours) / (30 * (3500 INR))");
+
+    assert!(result.success, "calculation failed: {:?}", result.error);
+    assert_eq!(result.result, "0.01188571428571429");
+    assert_eq!(result.fraction.as_deref(), Some("52/4375"));
+}


### PR DESCRIPTION
## Summary
- Treat raw date-difference durations divided by currency as numeric day counts.
- Drop explicit duration units when a converted duration count, such as hours, is divided by currency.
- Add regression coverage for the issue input, a localized INR currency name, and explicit hour conversion.

## Reproduction
Before this change:
- `(((2026-08-08) - (2026-06-17)) / (30 * (3500 INR)))` failed with `Invalid operation: Cannot divide duration by INR`.
- `(((2026-08-08) - (2026-06-17)) as hours) / (30 * (3500 INR))` returned a value with an incorrect trailing `hours` unit.

After this change:
- The issue input returns `0.000495238095238095` (`13/26250`).
- The localized `3500 рупий` form returns the same result.
- Explicit `as hours` conversion divides as a numeric hour count and returns `0.01188571428571429` (`52/4375`).

## Tests
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features`
- `node scripts/check-file-size.mjs`
- `node scripts/check-changelog-fragment.mjs`
- `cargo test --test issue_193_duration_currency_division_tests`
- `cargo test --test issue_191_duration_day_count_tests`
- `cargo test --test issue_187_duration_division_tests`
- `cargo test` (full local log saved to `target/cargo-test.log`)
- Manual CLI check for the issue input

Fixes #193