### PR TITLE
fix: parse locale comma numbers

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-28T21:52:56.502Z for PR creation at branch issue-195-f6006bdc4a9c for issue https://github.com/link-assistant/calculator/issues/195
+# Updated: 2026-07-03T10:53:35.701Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-06-28T21:52:56.502Z for PR creation at branch issue-195-f6006bdc4a9c for issue https://github.com/link-assistant/calculator/issues/195
-# Updated: 2026-07-03T10:53:35.701Z

--- a/changelog.d/20260703_110000_locale_number_parsing.md
+++ b/changelog.d/20260703_110000_locale_number_parsing.md
@@ -1,0 +1,2 @@
+### Fixed
+- Parse comma-decimal numbers such as `82,6172 / 100` using supported locale number conventions and expose ambiguous comma-number interpretations.

--- a/src/grammar/expression_parser.rs
+++ b/src/grammar/expression_parser.rs
@@ -18,6 +18,9 @@ use std::cmp::Ordering;
 #[path = "expression_parser_timezone.rs"]
 mod timezone;
 
+#[path = "expression_parser_locale.rs"]
+mod locale;
+
 /// Evaluates a power expression, using exact rational arithmetic when possible.
 ///
 /// When both base and exponent are rational and the exponent is an integer
@@ -141,8 +144,7 @@ impl ExpressionParser {
         Ok((value, steps, lino))
     }
 
-    /// Parses an expression string into an Expression AST.
-    pub fn parse(&self, input: &str) -> Result<Expression, CalculatorError> {
+    pub(super) fn parse_tokenized(&self, input: &str) -> Result<Expression, CalculatorError> {
         let mut lexer = Lexer::new(input);
         let tokens = lexer.tokenize()?;
         let mut parser = TokenParser::new(&tokens, &self.number_grammar, input);

--- a/src/grammar/expression_parser_locale.rs
+++ b/src/grammar/expression_parser_locale.rs
@@ -1,0 +1,48 @@
+//! Locale-aware parser fallback for number input.
+
+use crate::error::CalculatorError;
+use crate::grammar::{locale_numbers, ExpressionParser};
+use crate::types::Expression;
+
+impl ExpressionParser {
+    /// Parses an expression string into an Expression AST.
+    pub fn parse(&self, input: &str) -> Result<Expression, CalculatorError> {
+        let interpretations = self.parse_interpretations(input)?;
+        interpretations
+            .into_iter()
+            .next()
+            .ok_or_else(|| CalculatorError::parse("No parseable interpretation"))
+    }
+
+    /// Parses an expression into every supported locale interpretation.
+    ///
+    /// The ordinary grammar is tried first and wins when it succeeds. If the
+    /// ordinary grammar rejects the input, common locale number conventions are
+    /// normalized to the grammar's canonical decimal-dot format and tried in a
+    /// stable order.
+    pub fn parse_interpretations(&self, input: &str) -> Result<Vec<Expression>, CalculatorError> {
+        match self.parse_tokenized(input) {
+            Ok(expr) => Ok(vec![expr]),
+            Err(first_error) => {
+                let mut interpretations = Vec::new();
+                let mut linos = Vec::new();
+
+                for variant in locale_numbers::variants(input) {
+                    if let Ok(expr) = self.parse_tokenized(&variant) {
+                        let lino = expr.to_lino();
+                        if !linos.contains(&lino) {
+                            linos.push(lino);
+                            interpretations.push(expr);
+                        }
+                    }
+                }
+
+                if interpretations.is_empty() {
+                    Err(first_error)
+                } else {
+                    Ok(interpretations)
+                }
+            }
+        }
+    }
+}

--- a/src/grammar/locale_numbers.rs
+++ b/src/grammar/locale_numbers.rs
@@ -1,0 +1,188 @@
+//! Locale-aware number normalization helpers.
+//!
+//! The grammar itself uses `.` as the decimal separator. These helpers build
+//! normalized expression variants for user input that uses decimal/grouping
+//! conventions from supported UI locales, such as `82,6172` or `1.234,56`.
+
+#[derive(Debug, Clone, Copy)]
+struct NumberLocale {
+    decimal_separator: char,
+    grouping_separator: Option<char>,
+}
+
+const LOCALES: &[NumberLocale] = &[
+    // Russian, German, French, and other comma-decimal inputs without grouping.
+    NumberLocale {
+        decimal_separator: ',',
+        grouping_separator: None,
+    },
+    // German/Russian style: 1.234,56 -> 1234.56.
+    NumberLocale {
+        decimal_separator: ',',
+        grouping_separator: Some('.'),
+    },
+    // English/Hindi/Chinese style: 1,234.56 -> 1234.56.
+    NumberLocale {
+        decimal_separator: '.',
+        grouping_separator: Some(','),
+    },
+];
+
+/// Returns normalized variants of `input` using supported locale number
+/// conventions. Variants are ordered by locale preference and de-duplicated.
+pub(super) fn variants(input: &str) -> Vec<String> {
+    let mut variants = Vec::new();
+
+    for locale in LOCALES {
+        if let Some(variant) = rewrite_with_locale(input, *locale) {
+            push_unique(&mut variants, variant);
+        }
+    }
+
+    variants
+}
+
+fn rewrite_with_locale(input: &str, locale: NumberLocale) -> Option<String> {
+    let mut output = String::with_capacity(input.len());
+    let mut chars = input.char_indices().peekable();
+    let mut changed = false;
+
+    while let Some((start, ch)) = chars.next() {
+        if !ch.is_ascii_digit() {
+            output.push(ch);
+            continue;
+        }
+
+        let mut end = start + ch.len_utf8();
+        while let Some(&(idx, next)) = chars.peek() {
+            if next.is_ascii_digit() || next == '.' || next == ',' {
+                chars.next();
+                end = idx + next.len_utf8();
+            } else {
+                break;
+            }
+        }
+
+        let candidate = &input[start..end];
+        if let Some(normalized) = normalize_number(candidate, locale) {
+            if normalized != candidate {
+                changed = true;
+            }
+            output.push_str(&normalized);
+        } else {
+            output.push_str(candidate);
+        }
+    }
+
+    changed.then_some(output)
+}
+
+fn normalize_number(candidate: &str, locale: NumberLocale) -> Option<String> {
+    if !candidate
+        .chars()
+        .any(|ch| ch == locale.decimal_separator || Some(ch) == locale.grouping_separator)
+    {
+        return None;
+    }
+
+    let decimal_count = candidate
+        .chars()
+        .filter(|ch| *ch == locale.decimal_separator)
+        .count();
+
+    if decimal_count > 1 {
+        return normalize_grouped_integer(candidate, locale);
+    }
+
+    if decimal_count == 1 {
+        return normalize_decimal(candidate, locale);
+    }
+
+    normalize_grouped_integer(candidate, locale)
+}
+
+fn normalize_decimal(candidate: &str, locale: NumberLocale) -> Option<String> {
+    let (integer, fraction) = candidate.split_once(locale.decimal_separator)?;
+    if integer.is_empty() || fraction.is_empty() || !fraction.chars().all(|ch| ch.is_ascii_digit())
+    {
+        return None;
+    }
+
+    let integer = normalize_integer_part(integer, locale)?;
+    Some(format!("{integer}.{fraction}"))
+}
+
+fn normalize_grouped_integer(candidate: &str, locale: NumberLocale) -> Option<String> {
+    let group = locale.grouping_separator?;
+    if !candidate.contains(group) {
+        return None;
+    }
+
+    normalize_integer_part(candidate, locale)
+}
+
+fn normalize_integer_part(integer: &str, locale: NumberLocale) -> Option<String> {
+    if integer.is_empty() {
+        return None;
+    }
+
+    let group = locale.grouping_separator;
+    if let Some(group) = group {
+        if integer.contains(group) {
+            let groups: Vec<&str> = integer.split(group).collect();
+            let first = groups.first()?;
+            if first.is_empty() || first.len() > 3 || !first.chars().all(|ch| ch.is_ascii_digit()) {
+                return None;
+            }
+
+            if groups
+                .iter()
+                .skip(1)
+                .any(|part| part.len() != 3 || !part.chars().all(|ch| ch.is_ascii_digit()))
+            {
+                return None;
+            }
+
+            return Some(groups.join(""));
+        }
+    }
+
+    integer.chars().all(|ch| ch.is_ascii_digit()).then(|| {
+        integer
+            .chars()
+            .filter(|ch| Some(*ch) != group)
+            .collect::<String>()
+    })
+}
+
+fn push_unique(values: &mut Vec<String>, value: String) {
+    if !values.contains(&value) {
+        values.push(value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::variants;
+
+    #[test]
+    fn normalizes_decimal_comma() {
+        assert_eq!(variants("82,6172 / 100"), vec!["82.6172 / 100"]);
+    }
+
+    #[test]
+    fn exposes_ambiguous_comma_interpretations() {
+        assert_eq!(variants("1,234 / 100"), vec!["1.234 / 100", "1234 / 100"]);
+    }
+
+    #[test]
+    fn normalizes_grouped_decimal_forms() {
+        assert_eq!(variants("1.234,56"), vec!["1234.56"]);
+        assert_eq!(variants("1,234.56"), vec!["1234.56"]);
+    }
+
+    #[test]
+    fn ignores_argument_separator_with_spaces() {
+        assert!(variants("integrate(x^2, x, 0, 3)").is_empty());
+    }
+}

--- a/src/grammar/mod.rs
+++ b/src/grammar/mod.rs
@@ -5,6 +5,7 @@ mod expression_parser;
 mod integral;
 mod lexer;
 mod linear_equation;
+mod locale_numbers;
 mod math_functions;
 mod number_grammar;
 mod polynomial_equation;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -628,8 +628,16 @@ impl Calculator {
             return plan::empty_plan();
         }
 
-        match self.parser.parse(input) {
-            Ok(expr) => plan::create_plan(input, &expr),
+        match self.parser.parse_interpretations(input) {
+            Ok(interpretations) => {
+                if let Some(expr) = interpretations.first() {
+                    let mut plan = plan::create_plan(input, expr);
+                    plan.alternative_lino = Self::combined_alternative_lino(&interpretations);
+                    plan
+                } else {
+                    plan::error_plan(input, "Parse error: no parseable interpretation")
+                }
+            }
             Err(e) => plan::error_plan(input, &e.to_string()),
         }
     }
@@ -638,10 +646,13 @@ impl Calculator {
     pub fn calculate_internal(&mut self, input: &str) -> CalculationResult {
         // Try to parse the expression to generate alternative interpretations
         // and detect live time expressions before evaluation.
-        let parsed_expr = self.parser.parse(input).ok();
-        let alternatives = parsed_expr.as_ref().and_then(Expression::alternative_lino);
-        let is_live_time = parsed_expr
+        let parsed_interpretations = self.parser.parse_interpretations(input).ok();
+        let alternatives = parsed_interpretations
             .as_ref()
+            .and_then(|interpretations| Self::combined_alternative_lino(interpretations));
+        let is_live_time = parsed_interpretations
+            .as_ref()
+            .and_then(|interpretations| interpretations.first())
             .is_some_and(Expression::contains_live_time);
 
         let mut result = match self.parser.parse_and_evaluate(input) {
@@ -678,6 +689,29 @@ impl Calculator {
         result.alternative_lino = alternatives;
 
         result
+    }
+
+    fn combined_alternative_lino(interpretations: &[Expression]) -> Option<Vec<String>> {
+        let first = interpretations.first()?;
+        let mut alternatives = vec![first.to_lino()];
+
+        for expr in interpretations {
+            if let Some(expr_alternatives) = expr.alternative_lino() {
+                for lino in expr_alternatives {
+                    Self::push_unique_lino(&mut alternatives, lino);
+                }
+            } else {
+                Self::push_unique_lino(&mut alternatives, expr.to_lino());
+            }
+        }
+
+        (alternatives.len() > 1).then_some(alternatives)
+    }
+
+    fn push_unique_lino(alternatives: &mut Vec<String>, lino: String) {
+        if !alternatives.contains(&lino) {
+            alternatives.push(lino);
+        }
     }
 
     /// Generates plot data for an integral expression.

--- a/tests/issue_197_locale_number_tests.rs
+++ b/tests/issue_197_locale_number_tests.rs
@@ -1,0 +1,29 @@
+//! Regression tests for issue #197.
+//!
+//! Users may enter numbers using decimal/grouping conventions from their
+//! browser languages. The parser should try supported locale conventions
+//! instead of rejecting comma-decimal input outright.
+
+use link_calculator::Calculator;
+
+#[test]
+fn decimal_comma_expression_calculates() {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("82,6172 / 100");
+
+    assert!(result.success, "calculation failed: {:?}", result.error);
+    assert_eq!(result.result, "0.826172");
+    assert_eq!(result.lino_interpretation, "(82.6172 / 100)");
+}
+
+#[test]
+fn ambiguous_comma_number_exposes_locale_interpretations() {
+    let calc = Calculator::new();
+    let plan = calc.plan_internal("1,234 / 100");
+
+    assert!(plan.success, "plan failed: {:?}", plan.error);
+    assert_eq!(plan.lino_interpretation, "(1.234 / 100)");
+
+    let alternatives = plan.alternative_lino.expect("missing alternatives");
+    assert_eq!(alternatives, vec!["(1.234 / 100)", "(1234 / 100)"]);
+}


### PR DESCRIPTION
Fixes #197

## Summary
- Added a parser fallback that tries supported locale number conventions after ordinary parsing rejects input.
- Normalizes comma-decimal and grouped decimal forms into the canonical decimal-dot grammar representation.
- Combines locale-derived full-expression interpretations with existing `alternative_lino` options.

## Reproduction
- Before: `82,6172 / 100` failed with `Unexpected trailing input ',' at position 2`.
- After: it calculates as `0.826172` with LINO `(82.6172 / 100)`.

## Tests
- `cargo test`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features`
- `node scripts/check-file-size.mjs`
- `node scripts/check-changelog-fragment.mjs`

Parser-only change; no UI screenshot is included.