### PR TITLE
fix: support natural day span queries

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-06-28T21:52:56.502Z for PR creation at branch issue-195-f6006bdc4a9c for issue https://github.com/link-assistant/calculator/issues/195
-# Updated: 2026-07-24T05:43:34.962Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-28T21:52:56.502Z for PR creation at branch issue-195-f6006bdc4a9c for issue https://github.com/link-assistant/calculator/issues/195
+# Updated: 2026-07-24T05:43:34.962Z

--- a/changelog.d/20260724_207_time_span_days.md
+++ b/changelog.d/20260724_207_time_span_days.md
@@ -1,0 +1,2 @@
+### Added
+- Support ordinal dates with optional `of` and natural `days between` / `days to` time-span queries.

--- a/src/grammar/token_parser.rs
+++ b/src/grammar/token_parser.rs
@@ -235,7 +235,9 @@ impl<'a> TokenParser<'a> {
             // If followed by an identifier that looks like a month name (e.g., "17 February 2027"
             // or "17 февраля 2027"), try to parse the whole as a datetime expression.
             if let Some(TokenKind::Identifier(id)) = self.current_kind() {
-                if DateTimeGrammar::looks_like_datetime(id) {
+                let is_ordinal_suffix =
+                    matches!(id.to_lowercase().as_str(), "st" | "nd" | "rd" | "th");
+                if DateTimeGrammar::looks_like_datetime(id) || is_ordinal_suffix {
                     let save_before_dt = self.pos;
                     if let Ok(dt) = self.try_parse_datetime_from_tokens(&num_str) {
                         return Ok(dt);
@@ -461,6 +463,10 @@ impl<'a> TokenParser<'a> {
                     parts.push(id.clone());
                     self.advance();
                 }
+                Some(TokenKind::Of) => {
+                    parts.push("of".to_string());
+                    self.advance();
+                }
                 Some(TokenKind::Comma) => {
                     parts.push(",".to_string());
                     self.advance();
@@ -634,6 +640,11 @@ impl<'a> TokenParser<'a> {
                     }
                     token_positions.push(self.pos);
                     parts.push(id.clone());
+                    self.advance();
+                }
+                Some(TokenKind::Of) => {
+                    token_positions.push(self.pos);
+                    parts.push("of".to_string());
                     self.advance();
                 }
                 Some(TokenKind::Comma) => {

--- a/src/grammar/token_parser/comparison.rs
+++ b/src/grammar/token_parser/comparison.rs
@@ -1,6 +1,6 @@
 use crate::error::CalculatorError;
 use crate::grammar::TokenKind;
-use crate::types::{ComparisonOp, Expression};
+use crate::types::{BinaryOp, ComparisonOp, DurationUnit, Expression, Unit};
 
 use super::TokenParser;
 
@@ -10,6 +10,10 @@ impl TokenParser<'_> {
     }
 
     fn parse_comparison(&mut self) -> Result<Expression, CalculatorError> {
+        if let Some(day_span) = self.try_parse_day_span()? {
+            return Ok(day_span);
+        }
+
         if self.check_compare() {
             self.advance(); // consume "compare"
             let left = self.parse_additive()?;
@@ -38,6 +42,44 @@ impl TokenParser<'_> {
         }
 
         Ok(left)
+    }
+
+    /// Parses natural day-span queries:
+    /// - `days between <datetime> and <datetime>`
+    /// - `days to <datetime>` (the target datetime minus now)
+    fn try_parse_day_span(&mut self) -> Result<Option<Expression>, CalculatorError> {
+        let Some(TokenKind::Identifier(unit)) = self.current_kind() else {
+            return Ok(None);
+        };
+        if !unit.eq_ignore_ascii_case("days") {
+            return Ok(None);
+        }
+
+        let is_between = matches!(
+            self.peek_kind(),
+            Some(TokenKind::Identifier(keyword)) if keyword.eq_ignore_ascii_case("between")
+        );
+        let is_to = matches!(self.peek_kind(), Some(TokenKind::To));
+        if !is_between && !is_to {
+            return Ok(None);
+        }
+
+        self.advance(); // consume "days"
+        self.advance(); // consume "between" or "to"
+
+        let left = self.parse_additive()?;
+        let difference = if is_between {
+            self.expect(&TokenKind::And)?;
+            let right = self.parse_additive()?;
+            Expression::binary(left, BinaryOp::Subtract, right)
+        } else {
+            Expression::binary(left, BinaryOp::Subtract, Expression::Now)
+        };
+
+        Ok(Some(Expression::unit_conversion(
+            difference,
+            Unit::Duration(DurationUnit::Days),
+        )))
     }
 
     fn match_ordering_op(&mut self) -> Option<ComparisonOp> {

--- a/src/types/datetime_parse.rs
+++ b/src/types/datetime_parse.rs
@@ -174,7 +174,7 @@ pub(super) fn translate_month_names(input: &str) -> String {
 }
 
 /// Pre-processes natural date strings by removing day names, ordinal suffixes,
-/// and the "on" preposition.
+/// and optional "on"/"of" prepositions.
 pub(super) fn preprocess_natural_date(input: &str) -> String {
     let mut result = input.to_string();
 
@@ -217,8 +217,12 @@ pub(super) fn preprocess_natural_date(input: &str) -> String {
         }
     }
 
-    // Remove "on " preposition (often between time and date)
-    result = result.replace(" on ", " ");
+    // Remove optional prepositions used in natural date phrases such as
+    // "on January 26th" and "8th of August".
+    if let Ok(re) = regex::Regex::new(r"(?i)\b(?:on|of)\b") {
+        result = re.replace_all(&result, "").to_string();
+        result = result.split_whitespace().collect::<Vec<_>>().join(" ");
+    }
 
     // Remove ordinal suffixes from day numbers (1st, 2nd, 3rd, 4th-31st)
     let re_result = regex::Regex::new(r"(\d{1,2})(st|nd|rd|th)\b");

--- a/tests/issue_207_time_span_days_tests.rs
+++ b/tests/issue_207_time_span_days_tests.rs
@@ -1,0 +1,63 @@
+//! Regression tests for issue #207 and its sub-issues #203-#206.
+
+use link_calculator::Calculator;
+
+#[test]
+fn reported_time_span_expressions_are_supported() {
+    let mut calculator = Calculator::new();
+
+    for expression in [
+        "days between 8th august and now",
+        "((8th august - now) as days)",
+        "8th of august - now",
+        "days to 8th of august",
+    ] {
+        let result = calculator.calculate_internal(expression);
+        assert!(
+            result.success,
+            "{expression:?} should succeed: {:?}",
+            result.error
+        );
+    }
+}
+
+#[test]
+fn days_between_returns_the_first_date_minus_the_second_in_days() {
+    let mut calculator = Calculator::new();
+    let result =
+        calculator.calculate_internal("days between 8th august 2026 and 24th of july 2026");
+
+    assert!(result.success, "calculation failed: {:?}", result.error);
+    assert_eq!(result.result, "15 days");
+}
+
+#[test]
+fn days_to_matches_target_date_minus_now_in_days() {
+    let mut calculator = Calculator::new();
+    let natural = calculator.calculate_internal("days to 8th of august");
+    let explicit = calculator.calculate_internal("(8 august - now) as days");
+
+    assert!(natural.success, "natural form failed: {:?}", natural.error);
+    assert!(
+        explicit.success,
+        "explicit form failed: {:?}",
+        explicit.error
+    );
+
+    let natural_days = natural
+        .result
+        .strip_suffix(" days")
+        .expect("natural result should use days")
+        .parse::<f64>()
+        .expect("natural result should be numeric");
+    let explicit_days = explicit
+        .result
+        .strip_suffix(" days")
+        .expect("explicit result should use days")
+        .parse::<f64>()
+        .expect("explicit result should be numeric");
+    assert!(
+        (natural_days - explicit_days).abs() <= 2.0 / 86_400.0,
+        "forms should differ by at most their evaluation time: {natural_days} vs {explicit_days}"
+    );
+}


### PR DESCRIPTION
## Summary

- parse ordinal month dates such as `8th august`
- accept the optional `of` preposition in dates such as `8th of august`
- support `days between <date> and <date>` and `days to <date>` as signed day-count queries
- route natural queries through the existing datetime subtraction and duration conversion behavior

## Reproduction

Before this change, all four reported expressions failed to parse:

```text
days between 8th august and now
((8th august - now) as days)
8th of august - now
days to 8th of august
```

The regression suite covers every reported expression and verifies the deterministic query `days between 8th august 2026 and 24th of july 2026` returns `15 days`.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `node scripts/check-file-size.mjs`
- `node --test scripts/*.test.mjs`
- `cargo test --all-features --verbose`
- `cargo test --doc --verbose`
- `cargo build --release --verbose`
- `cargo package --list --allow-dirty`
- `wasm-pack build --target web --out-dir web/public/pkg`
- `npx tsc --noEmit`
- `npm test` (229 tests)
- `npm run build`

Fixes #207
Fixes #203
Fixes #204
Fixes #205
Fixes #206
