### PR TITLE
fix: recognize Russian ruble abbreviation 'руб' (#209)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-28T21:52:56.502Z for PR creation at branch issue-195-f6006bdc4a9c for issue https://github.com/link-assistant/calculator/issues/195
+# Updated: 2026-08-04T07:32:36.135Z

--- a/changelog.d/20260804_120000_ruble_abbreviation.md
+++ b/changelog.d/20260804_120000_ruble_abbreviation.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+### Fixed
+- Recognize the Russian ruble abbreviation `руб` (and `рубл`) as RUB, so expressions like `20000 руб + 120000 руб + 25000 рублей` calculate instead of failing with "cannot add 'руб' and 'RUB'" ([#209](https://github.com/link-assistant/calculator/issues/209)).
+- Accept a trailing dot on abbreviated units (`руб.`, `кг.`), which previously raised `Unexpected character '.'`.

--- a/src/grammar/lexer.rs
+++ b/src/grammar/lexer.rs
@@ -513,6 +513,18 @@ impl Lexer {
             }
         }
 
+        // Abbreviations are commonly written with a trailing dot ("руб.", "кг.", "янв.").
+        // Consume that dot when it terminates the word, i.e. when it is not followed by
+        // another word character (so "янв.2026" or "3.5" are left untouched).
+        if !text.is_empty()
+            && self.current() == '.'
+            && !self
+                .peek()
+                .is_some_and(|c| c.is_alphanumeric() || c == '_' || is_unicode_mark(c))
+        {
+            self.advance();
+        }
+
         // Check for keywords (including multilingual equivalents)
         let kind = match text.to_lowercase().as_str() {
             "at" => TokenKind::At,

--- a/src/types/currency.rs
+++ b/src/types/currency.rs
@@ -526,6 +526,11 @@ impl CurrencyDatabase {
             // Prepositional: рубле, рублях
             "рубль" | "рубля" | "рубле" | "рубли" | "рублей" | "рублям" | "рублю" | "рублём"
             | "рублем" | "рублями" | "рублях" => return Some("RUB".to_string()),
+            // Common Russian abbreviations for RUB. The trailing dot of "руб." / "рубл."
+            // is stripped by the lexer, so only the dotless forms are listed here.
+            // A bare "р" is intentionally not accepted: single Latin/Cyrillic letters are
+            // used as variable names in equations.
+            "руб" | "рубл" => return Some("RUB".to_string()),
             // Russian language names for VND (Vietnamese Dong, all grammatical cases/forms)
             // Nominative: донг, донги; Genitive: донга, донгов;
             // Dative: донгу, донгам; Instrumental: донгом, донгами;

--- a/tests/issue_209_ruble_abbreviation_tests.rs
+++ b/tests/issue_209_ruble_abbreviation_tests.rs
@@ -1,0 +1,67 @@
+//! Regression tests for issue #209.
+//!
+//! The abbreviation "руб" (and its dotted form "руб.") is the most common way
+//! to write rubles in Russian. It used to be parsed as a custom unit, so
+//! `20000 руб + 25000 рублей` failed with "cannot add 'руб' and 'RUB'".
+
+use link_calculator::Calculator;
+
+#[test]
+fn abbreviated_and_spelled_out_rubles_add_up() {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("20000 руб + 120000 руб + 25000 рублей");
+
+    assert!(result.success, "calculation failed: {:?}", result.error);
+    assert_eq!(result.result, "165000 RUB");
+}
+
+#[test]
+fn abbreviation_with_trailing_dot_is_recognized() {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("1000 руб. + 500 руб");
+
+    assert!(result.success, "calculation failed: {:?}", result.error);
+    assert_eq!(result.result, "1500 RUB");
+}
+
+#[test]
+fn abbreviated_rubles_convert_to_other_currencies() {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("1000 руб в долларах");
+
+    assert!(result.success, "calculation failed: {:?}", result.error);
+    assert!(
+        result.result.ends_with(" USD"),
+        "unexpected result: {}",
+        result.result
+    );
+}
+
+#[test]
+fn trailing_dot_also_works_for_non_currency_units() {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("5 кг.");
+
+    assert!(result.success, "calculation failed: {:?}", result.error);
+    assert_eq!(result.result, "5 kg");
+}
+
+#[test]
+fn decimal_numbers_are_unaffected_by_trailing_dot_handling() {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("3.5 + 1");
+
+    assert!(result.success, "calculation failed: {:?}", result.error);
+    assert_eq!(result.result, "4.5");
+}
+
+#[test]
+fn bare_cyrillic_letter_is_still_a_variable_not_a_currency() {
+    let mut calc = Calculator::new();
+    let result = calc.calculate_internal("100 р + 100 р");
+
+    // "р" alone must not be treated as RUB, otherwise it could not be used as
+    // a variable name; it stays a custom unit and still adds to itself.
+    assert!(result.success, "calculation failed: {:?}", result.error);
+    assert_eq!(result.result, "200 р");
+}


### PR DESCRIPTION
Fixes #209

## Problem

```
20000 руб + 120000 руб + 25000 рублей
→ Unit mismatch: cannot add 'руб' and 'RUB'
```

`CurrencyDatabase::parse_currency` knows every grammatical form of `рубль` (`src/types/currency.rs:527`), but not the everyday abbreviation `руб`, so it fell through to `Unit::Custom("руб")` in `src/grammar/number_grammar.rs:152` and could not be combined with, or converted from, `RUB`.

The dotted form `100 руб.` failed even earlier, in the lexer: `Parse error: Unexpected character '.' at position 7`.

## Solution

- `src/types/currency.rs`: map `руб` / `рубл` to `RUB`. A bare `р` is intentionally **not** mapped — single letters are used as variable names in equations.
- `src/grammar/lexer.rs`: in `scan_identifier`, consume a trailing dot when it terminates a word (not followed by another word character). This makes `руб.`, `кг.`, `янв.` work while leaving `3.5` and `янв.2026` untouched.

## Verification

New regression suite `tests/issue_209_ruble_abbreviation_tests.rs`:

| Input | Before | After |
|---|---|---|
| `20000 руб + 120000 руб + 25000 рублей` | Unit mismatch error | `165000 RUB` |
| `1000 руб. + 500 руб` | Unexpected character `.` | `1500 RUB` |
| `1000 руб в долларах` | Cannot convert руб to USD | `11.17… USD` |
| `5 кг.` | Unexpected character `.` | `5 kg` |
| `3.5 + 1` | `4.5` | `4.5` (unchanged) |
| `100 р + 100 р` | `200 р` | `200 р` (still a custom unit/variable) |

`cargo test` — all 61 suites pass. `cargo fmt --check`, `cargo clippy --all-targets --all-features`, and `node scripts/check-file-size.mjs` are clean.

A changelog fragment (`bump: patch`) is included to trigger the release.